### PR TITLE
refactor clean up function

### DIFF
--- a/apps/web/src/routes/book-room/-reader/contents.tsx
+++ b/apps/web/src/routes/book-room/-reader/contents.tsx
@@ -19,20 +19,8 @@ function ReaderContents(props: ComponentPropsWithoutRef<"div">) {
 
       // Display the first page
       book.rendition.display();
-
-      // eslint-disable-next-line
-      return () => {
-        // 컴포넌트 언마운트 시 rendition 정리
-        if (book && book.rendition) {
-          try {
-            book.rendition.destroy();
-          } catch (e) {
-            console.error("Error destroying rendition:", e);
-          }
-        }
-      };
     },
-    [book], // book이 변경될 때만 콜백 재생성
+    [book],
   );
 
   return <div ref={setViewerRef} {...props} />;

--- a/apps/web/src/routes/book-room/-reader/context.tsx
+++ b/apps/web/src/routes/book-room/-reader/context.tsx
@@ -44,27 +44,10 @@ export function ReaderProvider({ children }: { children: React.ReactNode }) {
         }
       });
 
-    // Cleanup function
     return () => {
       mounted = false;
-
-      // 현재 상태의 book과 새로 생성된 epubBook 모두 정리
-      if (epubBook) {
-        if (epubBook.rendition) {
-          try {
-            epubBook.rendition.destroy();
-          } catch (e) {
-            console.error("Error destroying rendition:", e);
-          }
-        }
-        try {
-          epubBook.destroy();
-        } catch (e) {
-          console.error("Error destroying book:", e);
-        }
-      }
-
-      setBook(null); // 상태 명시적으로 비움
+      epubBook.destroy();
+      setBook(null);
     };
   }, [navigate]);
 

--- a/apps/web/src/routes/book-room/-reader/page-progress.tsx
+++ b/apps/web/src/routes/book-room/-reader/page-progress.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-import { useState, useEffect } from "react";
+import { useState, useCallback } from "react";
 
 import { Contents } from "@bookiwi/epubjs";
 
@@ -16,129 +14,82 @@ function ReaderPageProgress() {
   const [isContentTouched, setIsContentTouched] = useState(false);
   const { book } = useReader();
 
-  useEffect(() => {
-    if (!book || !book.rendition) return;
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || !book) return () => {};
 
-    // Track if user is dragging
-    let isDragging = false;
-    const cleanupFunctions: Array<() => void> = [];
+      let iframe: Document | undefined;
 
-    const handleTouchAndClick = (e: MouseEvent | TouchEvent) => {
-      // Check if there's any text selected
-      const iframe = e.currentTarget as Document;
-      const selection = iframe.getSelection();
+      // Track if user is dragging
+      let isDragging = false;
+      const handleMouseDown = () => {
+        isDragging = false;
+      };
+      const handleMouseMove = () => {
+        isDragging = true;
+      };
+      const handleTouchStart = () => {
+        isDragging = false;
+      };
+      const handleTouchMove = () => {
+        isDragging = true;
+      };
 
-      // Only toggle if not dragging and no text is selected
-      if (!isDragging && (!selection || selection.toString().trim() === "")) {
-        setIsContentTouched((prev) => !prev);
-      }
+      const handleNodeClick = () => setIsContentTouched(true);
+      const handleNodeTouchStart = () => setIsContentTouched(true);
+      const handleTouchAndClick = (e: MouseEvent | TouchEvent) => {
+        // Check if there's any text selected
+        const target = e.currentTarget as Document;
+        const selection = target.getSelection();
 
-      // Reset the dragging state
-      isDragging = false;
-    };
-
-    const handleMouseDown = () => {
-      isDragging = false;
-    };
-
-    const handleMouseMove = () => {
-      isDragging = true;
-    };
-
-    const handleTouchStart = () => {
-      isDragging = false;
-    };
-
-    const handleTouchMove = () => {
-      isDragging = true;
-    };
-
-    // After the book is rendered, the iframe will be available
-    const handleRendered = () => {
-      try {
-        // Contents[] 타입으로 명시적 캐스팅
-        const contents =
-          book.rendition.getContents() as unknown as Array<Contents>;
-        if (contents && contents.length > 0) {
-          const iframe = contents[0]?.document;
-          if (iframe) {
-            iframe.addEventListener("click", handleTouchAndClick);
-            iframe.addEventListener("mousedown", handleMouseDown);
-            iframe.addEventListener("mousemove", handleMouseMove);
-            iframe.addEventListener("touchstart", handleTouchStart);
-            iframe.addEventListener("touchmove", handleTouchMove);
-
-            // 정리 함수 등록
-            cleanupFunctions.push(() => {
-              if (iframe) {
-                try {
-                  iframe.removeEventListener("click", handleTouchAndClick);
-                  iframe.removeEventListener("mousedown", handleMouseDown);
-                  iframe.removeEventListener("mousemove", handleMouseMove);
-                  iframe.removeEventListener("touchstart", handleTouchStart);
-                  iframe.removeEventListener("touchmove", handleTouchMove);
-                } catch (e) {
-                  console.error("Error removing event listeners:", e);
-                }
-              }
-            });
-          }
+        // Only toggle if not dragging and no text is selected
+        if (!isDragging && (!selection || selection.toString().trim() === "")) {
+          setIsContentTouched((prev) => !prev);
         }
-      } catch (e) {
-        console.error("Error handling rendered event:", e);
-      }
-    };
 
-    // 이벤트 리스너 등록
-    try {
-      book.rendition.on("rendered", handleRendered);
-    } catch (e) {
-      console.error("Error adding rendered event listener:", e);
-    }
+        // Reset the dragging state
+        isDragging = false;
+      };
 
-    // 이미 렌더링된 상태라면 한번 실행
-    try {
-      const contents = book.rendition.getContents();
-      if (contents && Array.isArray(contents) && contents.length > 0) {
-        handleRendered();
-      }
-    } catch (e) {
-      console.error("Error checking initial contents:", e);
-    }
+      // After the book is rendered, the iframe will be available
+      book.rendition.on("rendered", () => {
+        const contents = book.rendition.getContents() as unknown as Contents[];
+        iframe = contents[0]?.document;
+        if (iframe) {
+          iframe.addEventListener("click", handleTouchAndClick);
 
-    // Cleanup
-    // eslint-disable-next-line
-    return () => {
-      // 등록된 모든 이벤트 리스너 제거
-      cleanupFunctions.forEach((cleanup) => {
-        try {
-          cleanup();
-        } catch (e) {
-          console.error("Error executing cleanup function:", e);
+          // Add drag detection events
+          iframe.addEventListener("mousedown", handleMouseDown);
+          iframe.addEventListener("mousemove", handleMouseMove);
+          iframe.addEventListener("touchstart", handleTouchStart);
+          iframe.addEventListener("touchmove", handleTouchMove);
         }
       });
 
-      // 렌더링 이벤트 제거
-      try {
-        if (
-          book &&
-          book.rendition &&
-          typeof book.rendition.off === "function"
-        ) {
-          book.rendition.off("rendered", handleRendered);
+      node.addEventListener("click", handleNodeClick);
+      node.addEventListener("touchstart", handleNodeTouchStart);
+
+      const removeEventListeners = () => {
+        if (iframe) {
+          iframe.removeEventListener("click", handleTouchAndClick);
+          iframe.removeEventListener("mousedown", handleMouseDown);
+          iframe.removeEventListener("mousemove", handleMouseMove);
+          iframe.removeEventListener("touchstart", handleTouchStart);
+          iframe.removeEventListener("touchmove", handleTouchMove);
         }
-      } catch (e) {
-        console.error("Error removing rendered event:", e);
-      }
-    };
-  }, [book]);
+        node.removeEventListener("click", handleNodeClick);
+        node.removeEventListener("touchstart", handleNodeTouchStart);
+      };
+
+      return () => {
+        removeEventListeners();
+      };
+    },
+    [book],
+  );
 
   return (
-    <div
-      className="size-full"
-      onClick={() => setIsContentTouched(true)}
-      onTouchStart={() => setIsContentTouched(true)}
-    >
+    <div className="size-full" ref={setRef}>
       <div
         className={cn(
           "w-full space-y-2 px-3 transition-opacity duration-200",


### PR DESCRIPTION
### 1. Book 객체 destroy 메소드만 사용

Book 객체의 destory 메소드는 Rendition 객채의 destroy 메소드도 실행.   
중복과 존재하지 않는 rendtion.destory 실행 시도를 막기 위해 Book 객체의 destory 메소드만 사용하는 걸로 수정.

### 2. iframe에 등록한 이벤트 핸들러 제거

다시 공부해 보니까 epubjs가 EventEmitter로 등록한 이벤트에 등록된 이벤트 리스너만 자동으로 제거.   
그러므로  ifram DOM에 직접 할당한 이벤트 리스너는 직접 제거. 
iframe 참조를 미리  변수에 저장해 두고 클로저를 활용해 클린업 함수에서 접근해 이벤트 리스너를 제거할 수 있도록 함.

### 3. Callback ref 사용

pageProgress 컴포넌트에서도 Callback ref를 사용해  iframe과 progress bar 이벤트 등록.



close #39 
