### PR TITLE
resize reader contents

### DIFF
--- a/apps/web/src/routes/book-room/-component/split-view/context.tsx
+++ b/apps/web/src/routes/book-room/-component/split-view/context.tsx
@@ -5,23 +5,26 @@ import {
   useMemo,
   Dispatch,
   SetStateAction,
+  useState,
 } from "react";
 
 import {
-  BOOK_PANE_SIZE_MIN,
   ANNOTATION_PANE_SIZE_MIN,
+  BOOK_PANE_SIZE_MIN,
 } from "./constants/pane-size";
 import useSplitViewPane from "./hooks/use-split-view-pane";
 
 export interface PaneType {
   resize: (delta: number) => void;
-  size: number;
-  setSize: Dispatch<SetStateAction<number>>;
+  size?: number;
+  setSize: Dispatch<SetStateAction<number | undefined>>;
 }
 
 interface SplitViewContextType {
   bookPane: PaneType;
   annotationPane: PaneType;
+  splitViewWidth: number | undefined;
+  setSplitViewWidth: Dispatch<SetStateAction<number | undefined>>;
 }
 
 const SplitViewContext = createContext<SplitViewContextType | undefined>(
@@ -43,21 +46,25 @@ interface SplitViewProps {
 }
 
 export function SplitViewProvider({ children }: SplitViewProps) {
+  const [splitViewWidth, setSplitViewWidth] = useState<number | undefined>();
+
   const bookPane = useSplitViewPane({
-    preferredSize: window.innerWidth,
+    preferredSize: splitViewWidth,
+    maxSize: splitViewWidth
+      ? splitViewWidth - ANNOTATION_PANE_SIZE_MIN
+      : undefined,
     minSize: BOOK_PANE_SIZE_MIN,
-    maxSize: window.innerWidth - ANNOTATION_PANE_SIZE_MIN,
   });
 
   const annotationPane = useSplitViewPane({
     preferredSize: ANNOTATION_PANE_SIZE_MIN,
+    maxSize: splitViewWidth ? splitViewWidth - BOOK_PANE_SIZE_MIN : undefined,
     minSize: ANNOTATION_PANE_SIZE_MIN,
-    maxSize: window.innerWidth - BOOK_PANE_SIZE_MIN,
   });
 
   const contextValue = useMemo(
-    () => ({ bookPane, annotationPane }),
-    [bookPane, annotationPane],
+    () => ({ bookPane, annotationPane, splitViewWidth, setSplitViewWidth }),
+    [bookPane, annotationPane, splitViewWidth, setSplitViewWidth],
   );
 
   return (

--- a/apps/web/src/routes/book-room/-component/split-view/hooks/use-split-view-pane.ts
+++ b/apps/web/src/routes/book-room/-component/split-view/hooks/use-split-view-pane.ts
@@ -9,7 +9,7 @@ export interface UseSplitViewPaneParams {
 }
 
 const useSplitViewPane = ({
-  preferredSize = 0,
+  preferredSize,
   minSize = 0,
   maxSize = Number.POSITIVE_INFINITY,
 }: UseSplitViewPaneParams) => {
@@ -17,7 +17,12 @@ const useSplitViewPane = ({
 
   const resize = useCallback(
     (delta: number) => {
-      setSize((prev) => prev && clamp(prev + delta, minSize, maxSize));
+      setSize((prev) => {
+        if (prev) {
+          return clamp(prev + delta, minSize, maxSize);
+        }
+        return prev;
+      });
     },
     [maxSize, minSize],
   );

--- a/apps/web/src/routes/book-room/-component/split-view/index.ts
+++ b/apps/web/src/routes/book-room/-component/split-view/index.ts
@@ -4,3 +4,5 @@ export { default as SplitViewSeparator } from "./separator";
 export * from "./context";
 export { default as useSplitViewPane } from "./hooks/use-split-view-pane";
 export { default as usePane } from "./hooks/use-pane";
+export * from "./constants/pane-size";
+export * from "./constants/type";

--- a/apps/web/src/routes/book-room/-component/split-view/pane-group.tsx
+++ b/apps/web/src/routes/book-room/-component/split-view/pane-group.tsx
@@ -1,4 +1,10 @@
-import { ComponentProps } from "react";
+import { ComponentProps, useCallback } from "react";
+
+import { useAnnotationPane } from "../viewer/annotation/context";
+
+import { Pane } from "./constants/type";
+import { useSplitViewContext } from "./context";
+import usePane from "./hooks/use-pane";
 
 import { cn } from "#/lib/utils";
 
@@ -9,8 +15,33 @@ function SplitViewPaneGroup({
   className,
   ...props
 }: SplitViewGroupProps) {
+  const { setSplitViewWidth } = useSplitViewContext();
+  const bookPane = usePane(Pane.BOOK);
+  const annotationPane = usePane(Pane.ANNOTATION);
+  const { isPinned } = useAnnotationPane();
+  const callbackRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (!el) return () => {};
+
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        setSplitViewWidth(entry.contentRect.width ?? undefined);
+        if (isPinned && annotationPane.size) {
+          bookPane.setSize(entry.contentRect.width - annotationPane.size);
+        }
+      });
+
+      observer.observe(el);
+      return () => {
+        observer.disconnect();
+      };
+    },
+    [setSplitViewWidth, bookPane, annotationPane.size, isPinned],
+  );
+
   return (
-    <div className={cn("flex", className)} {...props}>
+    <div ref={callbackRef} className={cn("flex", className)} {...props}>
       {children}
     </div>
   );

--- a/apps/web/src/routes/book-room/-component/viewer/annotation/header.tsx
+++ b/apps/web/src/routes/book-room/-component/viewer/annotation/header.tsx
@@ -1,7 +1,6 @@
 import { Pin, X } from "lucide-react";
 
-import { usePane } from "../../split-view";
-import { Pane } from "../../split-view/constants/type";
+import { Pane, usePane, useSplitViewContext } from "../../split-view";
 
 import { useAnnotationPane } from "./context";
 import { useAnnotationTab, TabType } from "./tabs/context";
@@ -14,20 +13,26 @@ function AnnotationHeader() {
   const { setTabState } = useAnnotationTab();
   const bookPane = usePane(Pane.BOOK);
   const annotationPane = usePane(Pane.ANNOTATION);
+  const { splitViewWidth } = useSplitViewContext();
 
   const handlePin = () => {
     if (isPinned) {
       unpin();
-      bookPane.setSize(window.innerWidth);
+      bookPane.setSize(splitViewWidth);
     } else {
       pin();
-      bookPane.setSize(window.innerWidth - annotationPane.size);
+      bookPane.setSize(() => {
+        if (splitViewWidth && annotationPane.size) {
+          return splitViewWidth - annotationPane.size;
+        }
+        return splitViewWidth;
+      });
     }
   };
 
   const handleClose = () => {
     close();
-    bookPane.setSize(window.innerWidth);
+    bookPane.setSize(undefined);
   };
 
   const handleTabChange = (value: TabType) => {

--- a/apps/web/src/routes/book-room/-component/viewer/index.tsx
+++ b/apps/web/src/routes/book-room/-component/viewer/index.tsx
@@ -1,16 +1,15 @@
 import {
+  Pane,
   SplitViewPane,
   SplitViewPaneGroup,
   SplitViewSeparator,
 } from "../split-view";
-import { Pane } from "../split-view/constants/type";
 
 import Annotation from "./annotation";
 import { useAnnotationPane } from "./annotation/context";
 import Book from "./book";
 
 import Overlay from "#/components/ui/overlay";
-import { cn } from "#/lib/utils";
 
 function Viewer() {
   const { isOpen, isPinned, close } = useAnnotationPane();
@@ -19,7 +18,7 @@ function Viewer() {
     <SplitViewPaneGroup className="relative min-h-0 flex-1 justify-end">
       <SplitViewPane
         pane={Pane.BOOK}
-        className={cn("absolute z-0 inset-0", "transition-all duration-200")}
+        className="absolute inset-0 z-0 transition-all duration-200"
       >
         <Book />
       </SplitViewPane>

--- a/apps/web/src/routes/book-room/-reader/contents.tsx
+++ b/apps/web/src/routes/book-room/-reader/contents.tsx
@@ -1,9 +1,10 @@
-import { useCallback, ComponentPropsWithoutRef } from "react";
+import { useCallback, ComponentPropsWithoutRef, useRef } from "react";
 
 import { useReader } from "./context";
 
 function ReaderContents(props: ComponentPropsWithoutRef<"div">) {
   const { book } = useReader();
+  const prevSize = useRef(0);
 
   const setViewerRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -17,8 +18,14 @@ function ReaderContents(props: ComponentPropsWithoutRef<"div">) {
 
       rendition.display();
 
-      const observer = new ResizeObserver(() => {
-        rendition.resize();
+      const observer = new ResizeObserver(([e]) => {
+        const size = e?.contentRect.width ?? 0;
+
+        if (size !== 0 && prevSize.current !== 0 && size !== prevSize.current) {
+          rendition.resize();
+        }
+
+        prevSize.current = size;
       });
 
       observer.observe(node);

--- a/apps/web/src/routes/book-room/-reader/contents.tsx
+++ b/apps/web/src/routes/book-room/-reader/contents.tsx
@@ -1,24 +1,38 @@
-import { useCallback, ComponentPropsWithoutRef } from "react";
+import { useCallback, ComponentPropsWithoutRef, useRef } from "react";
 
 import { useReader } from "./context";
 
 function ReaderContents(props: ComponentPropsWithoutRef<"div">) {
   const { book } = useReader();
+  const prevSize = useRef(0);
 
   const setViewerRef = useCallback(
     (node: HTMLDivElement | null) => {
-      // DOM 요소가 없거나 book이 없으면 아무것도 하지 않음
-      if (!node || !book) return;
+      if (!node || !book) return () => {};
 
-      // Render the book in the viewer
-      book.renderTo(node, {
+      const rendition = book.renderTo(node, {
         width: "100%",
         height: "100%",
-        allowScriptedContent: true,
+        allowScriptedContent: true, // 자바스크립트 실행 허용
       });
 
-      // Display the first page
-      book.rendition.display();
+      rendition.display();
+
+      const observer = new ResizeObserver(([e]) => {
+        const size = e?.contentRect.width ?? 0;
+
+        if (size !== 0 && prevSize.current !== 0) {
+          rendition.resize();
+        }
+
+        prevSize.current = size;
+      });
+
+      observer.observe(node);
+
+      return () => {
+        observer.disconnect();
+      };
     },
     [book],
   );

--- a/apps/web/src/routes/book-room/-reader/contents.tsx
+++ b/apps/web/src/routes/book-room/-reader/contents.tsx
@@ -1,10 +1,9 @@
-import { useCallback, ComponentPropsWithoutRef, useRef } from "react";
+import { useCallback, ComponentPropsWithoutRef } from "react";
 
 import { useReader } from "./context";
 
 function ReaderContents(props: ComponentPropsWithoutRef<"div">) {
   const { book } = useReader();
-  const prevSize = useRef(0);
 
   const setViewerRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -18,14 +17,8 @@ function ReaderContents(props: ComponentPropsWithoutRef<"div">) {
 
       rendition.display();
 
-      const observer = new ResizeObserver(([e]) => {
-        const size = e?.contentRect.width ?? 0;
-
-        if (size !== 0 && prevSize.current !== 0) {
-          rendition.resize();
-        }
-
-        prevSize.current = size;
+      const observer = new ResizeObserver(() => {
+        rendition.resize();
       });
 
       observer.observe(node);

--- a/packages/epubjs/types/rendition.d.ts
+++ b/packages/epubjs/types/rendition.d.ts
@@ -121,7 +121,7 @@ export default class Rendition {
 
   requireView(view: string | Function | object): any;
 
-  resize(width: number, height: number): void;
+  resize(width?: number, height?: number): void;
 
   setManager(manager: Function): void;
 


### PR DESCRIPTION
## 구현 기능
책 크기가 변경될 시 책 컨텐츠를 크기에 맞게 조정하는 기능을 구현.   

Flow 코드를 참고해서 구현.  


## ResizeObserver

등록한 Element의 크기 변화를 관찰하고 콜백을 실행하는Web API 인 ResizeObserver를 사용해서 구현.

[트러블 슈팅 링크](https://github.com/Bookiwi-hub/bookiwi-frontend/wiki/ResizeObserver-for-Monitoring-Resizable-Containers)

## epubjs resize() 메소드

rendition.resize() 메소드를 사용해서 구현.  
메소드를 실행하면 내부 콘텐츠를 다시 개산해서 리렌더링 하는 기능을 하는 것으로 보임.  

원래 resize 메소드는 width와 height를 인자로 받게 되어 있는데, 재계산과 리렌더링만 트리거하기 위해 rendition.d.ts를 수정해 optinal로 만들어줌. 

#41 
