### PR TITLE
Optimizing a Slider with Throttling

### DIFF
--- a/apps/web/src/routes/book-room/-reader/page-progress/index.tsx
+++ b/apps/web/src/routes/book-room/-reader/page-progress/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { useReader } from "../context";
 
@@ -8,6 +8,7 @@ import useToggle from "./hooks/use-toggle";
 
 import { Slider } from "#/components/ui/slider";
 import { cn } from "#/lib/utils";
+import { throttle } from "#/utils/throttle";
 
 function ReaderPageProgress() {
   const { book } = useReader();
@@ -24,10 +25,18 @@ function ReaderPageProgress() {
     [pageRef, toggleRef, percentageRef],
   );
 
+  const throttledDisplay = useMemo(() => {
+    if (!book) return null;
+    return throttle((value: number) => {
+      if (!book || !value) return;
+      const cfi = book.locations.cfiFromPercentage(value / 100);
+      book.rendition.display(cfi);
+    }, 200);
+  }, [book]);
+
   const handleChangeSlider = (value: number[]) => {
-    if (!book || !value[0]) return;
-    const cfi = book.locations.cfiFromPercentage(value[0] / 100);
-    book.rendition.display(cfi);
+    if (!book || !value[0] || !throttledDisplay) return;
+    throttledDisplay(value[0]);
   };
 
   return (

--- a/apps/web/src/utils/throttle.ts
+++ b/apps/web/src/utils/throttle.ts
@@ -1,0 +1,40 @@
+/**
+ * 쓰로틀링 함수
+ * @param func - 쓰로틀할 함수
+ * @param wait - 제한 시간(밀리초)
+ * @returns 원본 함수의 쓰로틀된 버전
+ * @example
+ * // 300ms마다 최대 한 번만 실행되는 스크롤 이벤트 핸들러 쓰로틀
+ * const throttledScroll = throttle(() => {
+ *   updateScrollPosition();
+ * }, 300);
+ *
+ * // 스크롤 이벤트에 쓰로틀된 함수 연결
+ * window.addEventListener('scroll', throttledScroll);
+ */
+
+export const throttle = <T extends (...args: any[]) => any>(
+  func: T,
+  wait: number,
+): ((...args: Parameters<T>) => void) => {
+  let isThrottled = false;
+  let lastArgs: Parameters<T> | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (isThrottled) {
+      lastArgs = args;
+      return;
+    }
+
+    func(...args);
+    isThrottled = true;
+
+    setTimeout(() => {
+      isThrottled = false;
+      if (lastArgs) {
+        func(...lastArgs);
+        lastArgs = null;
+      }
+    }, wait);
+  };
+};


### PR DESCRIPTION
Slider에 버벅거림을 줄이기 위해 throttling 사용.
Slider가 가리키는 위치를 epubCFI로 찾고 렌더링 하는 작업을 throttling 걸음.
Throttling은 클로저를 활용해 간단하게 직접 구현.
클로저를 유지하기 위해 memoization을 사용함. (컴포넌트가 리렌더링 되면 함수를 새로 만들기 때문)