### PR TITLE
모바일에서 책 이전, 이후 기능 구현

### DIFF
--- a/apps/web/src/routes/kiwi/-mobile/-components/page-controls.tsx
+++ b/apps/web/src/routes/kiwi/-mobile/-components/page-controls.tsx
@@ -1,0 +1,124 @@
+import { ReactNode, useCallback, useRef } from "react";
+
+import { useReader } from "../../-reader/context";
+
+interface PageControlsProps {
+  children: ReactNode;
+}
+
+/**
+ * 모바일용 페이지 컨트롤 컴포넌트
+ * - 왼쪽 화면 클릭: 이전 페이지
+ * - 오른쪽 화면 클릭: 다음 페이지
+ * - 중앙 영역: 터치 이벤트 통과 (프로그레스 바용)
+ * - 스와이프 기능: 좌우 스와이프로 페이지 이동
+ */
+function PageControls({ children }: PageControlsProps) {
+  const { book } = useReader();
+  const touchStartX = useRef<number | null>(null);
+  const touchStartY = useRef<number | null>(null);
+
+  // 이전 페이지로 이동
+  const goToPrevPage = useCallback(() => {
+    if (book && book.rendition) {
+      book.rendition.prev();
+    }
+  }, [book]);
+
+  // 다음 페이지로 이동
+  const goToNextPage = useCallback(() => {
+    if (book && book.rendition) {
+      book.rendition.next();
+    }
+  }, [book]);
+
+  // 터치 시작 시 좌표 저장
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (e.touches && e.touches.length > 0) {
+      const touch = e.touches[0];
+      if (touch) {
+        touchStartX.current = touch.clientX;
+        touchStartY.current = touch.clientY;
+      }
+    }
+  }, []);
+
+  // 터치 종료 시 스와이프 동작 실행
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      // 시작 좌표가 없으면 처리하지 않음
+      if (!touchStartX.current || !touchStartY.current) return;
+
+      if (e.changedTouches && e.changedTouches.length > 0) {
+        const touch = e.changedTouches[0];
+        if (!touch) return;
+
+        const touchEndX = touch.clientX;
+        const touchEndY = touch.clientY;
+
+        // 수평/수직 이동 거리 계산
+        const diffX = touchStartX.current - touchEndX;
+        const diffY = touchStartY.current - touchEndY;
+
+        // 스와이프 최소 거리 (픽셀)
+        const minSwipeDistance = 50;
+
+        // 수평 스와이프가 수직보다 클 때만 스와이프로 인식
+        if (
+          Math.abs(diffX) > Math.abs(diffY) &&
+          Math.abs(diffX) > minSwipeDistance
+        ) {
+          // 왼쪽으로 스와이프: 다음 페이지
+          if (diffX > 0) {
+            goToNextPage();
+          }
+          // 오른쪽으로 스와이프: 이전 페이지
+          else {
+            goToPrevPage();
+          }
+        }
+      }
+
+      // 터치 좌표 초기화
+      touchStartX.current = null;
+      touchStartY.current = null;
+    },
+    [goToNextPage, goToPrevPage],
+  );
+
+  return (
+    <div
+      className="relative size-full overflow-hidden"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      {/* 페이지 컨트롤 영역 - 좌우 영역만 배치 */}
+      <div className="pointer-events-none absolute inset-0 z-10">
+        {/* 왼쪽 영역 - 이전 페이지 */}
+        <button
+          type="button"
+          className="pointer-events-auto absolute left-0 top-0 h-full w-1/3 cursor-pointer bg-transparent"
+          onClick={goToPrevPage}
+          onMouseDown={(e) => e.preventDefault()}
+          aria-label="이전 페이지"
+          tabIndex={-1}
+        />
+
+        {/* 오른쪽 영역 - 다음 페이지 */}
+        <button
+          type="button"
+          className="pointer-events-auto absolute right-0 top-0 h-full w-1/3 cursor-pointer bg-transparent"
+          onClick={goToNextPage}
+          onMouseDown={(e) => e.preventDefault()}
+          aria-label="다음 페이지"
+          tabIndex={-1}
+        />
+      </div>
+
+      {/* 실제 컨텐츠 영역 */}
+      <div className="size-full overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+export { PageControls };

--- a/apps/web/src/routes/kiwi/-mobile/book/index.tsx
+++ b/apps/web/src/routes/kiwi/-mobile/book/index.tsx
@@ -1,10 +1,15 @@
+import { PageControls } from "../-components/page-controls";
 import { ReaderContents, ReaderPageProgress } from "../../-reader";
 
 function MobileBook() {
   return (
-    <section className="relative flex size-full flex-col px-9">
-      <ReaderContents className="size-full" />
-      <div className="absolute inset-x-0 bottom-0 h-24 bg-white">
+    <section className="relative mx-auto flex size-full flex-col">
+      <div className="relative grow">
+        <PageControls>
+          <ReaderContents className="size-full" />
+        </PageControls>
+      </div>
+      <div className="absolute inset-x-0 bottom-0 h-16 bg-white">
         <ReaderPageProgress />
       </div>
     </section>

--- a/apps/web/src/routes/kiwi/-mobile/book/index.tsx
+++ b/apps/web/src/routes/kiwi/-mobile/book/index.tsx
@@ -2,9 +2,11 @@ import { ReaderContents, ReaderPageProgress } from "../../-reader";
 
 function MobileBook() {
   return (
-    <section className="relative flex size-full flex-col px-12">
+    <section className="relative flex size-full flex-col px-9">
       <ReaderContents className="size-full" />
-      <ReaderPageProgress />
+      <div className="absolute inset-x-0 bottom-0 h-24 bg-white">
+        <ReaderPageProgress />
+      </div>
     </section>
   );
 }

--- a/apps/web/src/routes/kiwi/-mobile/index.tsx
+++ b/apps/web/src/routes/kiwi/-mobile/index.tsx
@@ -3,13 +3,11 @@ import { useLoaderData } from "@tanstack/react-router";
 import { ReaderProvider } from "../-reader";
 import { SettingsProvider } from "../-reader/settings-context";
 
-import MobileHeader from "./header";
 import MobileViewer from "./viewer";
 
 function MobileKiwiContent() {
   return (
     <div className="size-full">
-      <MobileHeader />
       <MobileViewer />
     </div>
   );

--- a/apps/web/src/routes/kiwi/-mobile/index.tsx
+++ b/apps/web/src/routes/kiwi/-mobile/index.tsx
@@ -4,7 +4,6 @@ import { ReaderProvider } from "../-reader";
 import { SettingsProvider } from "../-reader/settings-context";
 
 import MobileHeader from "./header";
-import MobileMenu from "./menu";
 import MobileViewer from "./viewer";
 
 function MobileKiwiContent() {
@@ -12,7 +11,6 @@ function MobileKiwiContent() {
     <div className="size-full">
       <MobileHeader />
       <MobileViewer />
-      <MobileMenu />
     </div>
   );
 }


### PR DESCRIPTION
모바일에서 화면 기준 3분할하여 왼쪽, 중앙, 오른쪽 영역으로 나누어 책 페이지 이동 기능 구현
왼쪽에서 오른쪽 스와이프 또는 오른쪽에서 왼쪽 스와이프에도 책 페이지 이동 가능