### PR TITLE
refactor: add sections, navItems atoms

### DIFF
--- a/apps/web/src/routes/kiwi/-header/sidebar/panels/search.tsx
+++ b/apps/web/src/routes/kiwi/-header/sidebar/panels/search.tsx
@@ -1,11 +1,10 @@
 import { ChevronDown, ChevronRight, Search } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
 
-import Section from "@bookiwi/epubjs/types/section";
 import { useAtomValue } from "@bookiwi/jotai";
 
 import { Input } from "#/components/ui/input";
-import { bookAtom } from "#/routes/kiwi/-reader/atoms";
+import { bookAtom, sectionsAtom } from "#/routes/kiwi/-reader/atoms";
 import { debounce } from "#/utils/debounce";
 import truncate from "#/utils/truncate";
 
@@ -197,6 +196,7 @@ const MemoizedSearchResults = memo(SearchResults);
 
 function SearchPanel() {
   const book = useAtomValue(bookAtom);
+  const sections = useAtomValue(sectionsAtom);
   const [searchTerm, setSearchTerm] = useState("");
   const [matchResults, setMatchResults] = useState<MatchType[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -207,12 +207,6 @@ function SearchPanel() {
 
       return new Promise((resolve) => {
         const matchItems: MatchType[] = [];
-        const sections: Section[] = [];
-
-        // First, collect all the sections
-        book.spine.each((section: Section) => {
-          sections.push(section);
-        });
 
         let completedSearches = 0;
 
@@ -248,7 +242,7 @@ function SearchPanel() {
         });
       });
     },
-    [book],
+    [book, sections],
   );
 
   const handleSearch = useCallback(

--- a/apps/web/src/routes/kiwi/-header/sidebar/panels/toc.tsx
+++ b/apps/web/src/routes/kiwi/-header/sidebar/panels/toc.tsx
@@ -1,44 +1,48 @@
 import { ChevronDown, ChevronRight, BookOpen } from "lucide-react";
-import { useState, memo, useCallback } from "react";
+import { useState, memo } from "react";
 
+import { NavItem } from "@bookiwi/epubjs";
 import { useAtomValue } from "@bookiwi/jotai";
 
 import { cn } from "#/lib/utils";
-import { bookAtom, currentSectionAtom } from "#/routes/kiwi/-reader/atoms";
+import {
+  bookAtom,
+  currentSectionAtom,
+  navAtom,
+} from "#/routes/kiwi/-reader/atoms";
+import { mapSectionHrefToNavItem } from "#/routes/kiwi/-reader/utils/nav";
 
-interface NavItem {
-  href: string;
-  id?: string;
-  label: string;
-  subitems?: NavItem[];
-}
 interface TocItemComponentProps {
   item: NavItem;
-  handleNavClick: (href: string) => void;
   level?: number;
-  currentSectionHref?: string;
-  isActive?: boolean;
+  currentNavItem?: NavItem;
 }
 function TocItemComponent({
   item,
-  handleNavClick,
   level = 0,
-  currentSectionHref,
-  isActive,
+  currentNavItem,
 }: TocItemComponentProps) {
+  const book = useAtomValue(bookAtom);
   const [isOpen, setIsOpen] = useState(level === 0);
 
   // 서브목차 존재 여부 확인
   const hasSubitems = item.subitems && item.subitems.length > 0;
+
+  // 목차 항목 클릭 시 해당 페이지로 이동
+  const handleNavClick = () => {
+    if (book && book.rendition) {
+      book.rendition.display(item.href);
+    }
+  };
 
   return (
     <li>
       <div
         className={cn(
           "group flex cursor-pointer items-center rounded-md p-2 hover:bg-gray-100",
-          isActive && "bg-gray-100",
+          currentNavItem?.id === item.id && "bg-gray-100",
         )}
-        onClick={() => handleNavClick(item.href)}
+        onClick={handleNavClick}
         role="button"
         tabIndex={-1}
         onMouseDown={(e) => e.preventDefault()}
@@ -71,23 +75,14 @@ function TocItemComponent({
       </div>
       {hasSubitems && isOpen && (
         <ul className="ml-2 mt-1 space-y-1 border-l-2 border-gray-100 pl-2">
-          {item.subitems!.map((subitem, i) => {
-            const isActiveSubitem = currentSectionHref === subitem.href;
-            return (
-              <TocItemComponent
-                key={`${subitem.id || i}`}
-                item={subitem}
-                handleNavClick={handleNavClick}
-                level={level + 1}
-                isActive={isActiveSubitem}
-                currentSectionHref={
-                  !isActiveSubitem && subitem.subitems?.length
-                    ? currentSectionHref
-                    : undefined
-                }
-              />
-            );
-          })}
+          {item.subitems!.map((subitem, i) => (
+            <TocItemComponent
+              key={`${subitem.id || i}`}
+              item={subitem}
+              level={level + 1}
+              currentNavItem={currentNavItem}
+            />
+          ))}
         </ul>
       )}
     </li>
@@ -97,62 +92,31 @@ function TocItemComponent({
 const MemoizedTocItemComponent = memo(TocItemComponent);
 
 function TocPanel() {
-  const book = useAtomValue(bookAtom);
-  const [toc, setToc] = useState<NavItem[]>([]);
+  const navItems = useAtomValue(navAtom);
   const currentSection = useAtomValue(currentSectionAtom);
-  const currentSectionHref = currentSection?.href;
 
-  const tocRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (!node || !book) return;
-      book.loaded.navigation.then((navigation) => {
-        setToc(navigation.toc);
-      });
-    },
-    [book],
-  );
-  // 목차 항목 클릭 시 해당 페이지로 이동
-  const handleNavClick = useCallback(
-    (href: string) => {
-      if (book && book.rendition) {
-        book.rendition.display(href);
-      }
-    },
-    [book],
-  );
+  if (!navItems || !currentSection || !navItems.length)
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-center">
+        <BookOpen className="mb-2 size-8 text-gray-400" />
+        <p className="text-xs text-gray-500">목차가 없습니다.</p>
+      </div>
+    );
+
+  const currentNavItem = mapSectionHrefToNavItem(navItems, currentSection.href);
 
   return (
-    <div ref={tocRef}>
+    <div>
       <h3 className="mb-4 text-lg font-medium">목차</h3>
-      {toc.length > 0 ? (
-        <ul className="space-y-2">
-          {toc.map((item, index) => {
-            const isActive = currentSectionHref === item.href;
-
-            return (
-              <MemoizedTocItemComponent
-                key={item.id || index}
-                item={item}
-                handleNavClick={handleNavClick}
-                isActive={isActive}
-                currentSectionHref={
-                  !isActive && item.subitems?.length
-                    ? currentSectionHref
-                    : undefined
-                }
-              />
-            );
-          })}
-        </ul>
-      ) : (
-        <div className="flex flex-col items-center justify-center py-6 text-center">
-          <BookOpen className="mb-2 size-8 text-gray-400" />
-          <p className="text-sm text-gray-600">목차를 불러오는 중입니다</p>
-          <p className="text-xs text-gray-500">
-            잠시만 기다려주세요. 또는 이 책에 목차가 없을 수 있습니다.
-          </p>
-        </div>
-      )}
+      <ul className="space-y-2">
+        {navItems.map((item, index) => (
+          <MemoizedTocItemComponent
+            key={item.id || index}
+            item={item}
+            currentNavItem={currentNavItem}
+          />
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/web/src/routes/kiwi/-header/sidebar/panels/toc.tsx
+++ b/apps/web/src/routes/kiwi/-header/sidebar/panels/toc.tsx
@@ -10,23 +10,24 @@ import {
   currentSectionAtom,
   navAtom,
 } from "#/routes/kiwi/-reader/atoms";
-import { mapSectionHrefToNavItem } from "#/routes/kiwi/-reader/utils/nav";
 
 interface TocItemComponentProps {
   item: NavItem;
   level?: number;
-  currentNavItem?: NavItem;
+  currentHref?: string;
 }
 function TocItemComponent({
   item,
   level = 0,
-  currentNavItem,
+  currentHref,
 }: TocItemComponentProps) {
   const book = useAtomValue(bookAtom);
   const [isOpen, setIsOpen] = useState(level === 0);
 
   // 서브목차 존재 여부 확인
   const hasSubitems = item.subitems && item.subitems.length > 0;
+
+  const isActive = currentHref === item.href;
 
   // 목차 항목 클릭 시 해당 페이지로 이동
   const handleNavClick = () => {
@@ -40,7 +41,7 @@ function TocItemComponent({
       <div
         className={cn(
           "group flex cursor-pointer items-center rounded-md p-2 hover:bg-gray-100",
-          currentNavItem?.id === item.id && "bg-gray-100",
+          isActive && "bg-gray-100",
         )}
         onClick={handleNavClick}
         role="button"
@@ -80,7 +81,7 @@ function TocItemComponent({
               key={`${subitem.id || i}`}
               item={subitem}
               level={level + 1}
-              currentNavItem={currentNavItem}
+              currentHref={currentHref}
             />
           ))}
         </ul>
@@ -95,15 +96,13 @@ function TocPanel() {
   const navItems = useAtomValue(navAtom);
   const currentSection = useAtomValue(currentSectionAtom);
 
-  if (!navItems || !currentSection || !navItems.length)
+  if (!navItems || !navItems.length)
     return (
       <div className="flex flex-col items-center justify-center py-6 text-center">
         <BookOpen className="mb-2 size-8 text-gray-400" />
         <p className="text-xs text-gray-500">목차가 없습니다.</p>
       </div>
     );
-
-  const currentNavItem = mapSectionHrefToNavItem(navItems, currentSection.href);
 
   return (
     <div>
@@ -113,7 +112,7 @@ function TocPanel() {
           <MemoizedTocItemComponent
             key={item.id || index}
             item={item}
-            currentNavItem={currentNavItem}
+            currentHref={currentSection?.href}
           />
         ))}
       </ul>

--- a/apps/web/src/routes/kiwi/-reader/atoms/book.ts
+++ b/apps/web/src/routes/kiwi/-reader/atoms/book.ts
@@ -1,4 +1,4 @@
-import { Book, Location } from "@bookiwi/epubjs";
+import { Book, Location, NavItem } from "@bookiwi/epubjs";
 import Section from "@bookiwi/epubjs/types/section";
 import { atom } from "@bookiwi/jotai";
 
@@ -6,6 +6,7 @@ export const bookAtom = atom<Book | null>(null);
 
 export const currentSectionAtom = atom<Section>();
 export const currentLocationAtom = atom<Location>();
+export const navAtom = atom<NavItem[]>();
 export const isCenterTouchedAtom = atom<boolean>(false);
 
 export const toggleCenterTouchedAtom = atom(null, (get, set) => {

--- a/apps/web/src/routes/kiwi/-reader/atoms/book.ts
+++ b/apps/web/src/routes/kiwi/-reader/atoms/book.ts
@@ -7,6 +7,7 @@ export const bookAtom = atom<Book | null>(null);
 export const currentSectionAtom = atom<Section>();
 export const currentLocationAtom = atom<Location>();
 export const navAtom = atom<NavItem[]>();
+export const sectionsAtom = atom<Section[]>([]);
 export const isCenterTouchedAtom = atom<boolean>(false);
 
 export const toggleCenterTouchedAtom = atom(null, (get, set) => {

--- a/apps/web/src/routes/kiwi/-reader/hooks/index.ts
+++ b/apps/web/src/routes/kiwi/-reader/hooks/index.ts
@@ -3,3 +3,4 @@ export { default as useObserver } from "./use-observer";
 export { default as useRelocated } from "./use-relocated";
 export { default as useRendered } from "./use-rendered";
 export { default as useRender } from "./use-render";
+export { default as usePage } from "./use-page";

--- a/apps/web/src/routes/kiwi/-reader/hooks/use-page.ts
+++ b/apps/web/src/routes/kiwi/-reader/hooks/use-page.ts
@@ -1,0 +1,30 @@
+import { useAtomValue } from "@bookiwi/jotai";
+
+import { currentLocationAtom, currentSectionAtom, navAtom } from "../atoms";
+import { mapSectionHrefToNavItem } from "../utils/nav";
+
+import truncate from "#/utils/truncate";
+
+const MAX_SECTION_LENGTH = 25;
+
+const usePage = () => {
+  const currentSection = useAtomValue(currentSectionAtom);
+  const currentLocation = useAtomValue(currentLocationAtom);
+  const nav = useAtomValue(navAtom);
+
+  if (!nav || !currentSection || !currentLocation)
+    return { currentTocLabel: null, currentPage: null, totalPages: null };
+
+  const currentNavItem = mapSectionHrefToNavItem(nav, currentSection.href);
+
+  const currentTocLabel = truncate(
+    currentNavItem?.label || "",
+    MAX_SECTION_LENGTH,
+  );
+  const { page: currentPage, total: totalPages } = currentLocation.start
+    .displayed || { page: 0, total: 0 };
+
+  return { currentTocLabel, currentPage, totalPages };
+};
+
+export default usePage;

--- a/apps/web/src/routes/kiwi/-reader/page-progress.tsx
+++ b/apps/web/src/routes/kiwi/-reader/page-progress.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 
-import { Book } from "@bookiwi/epubjs";
 import { useAtom, useAtomValue } from "@bookiwi/jotai";
 
 import {
@@ -8,8 +7,10 @@ import {
   currentLocationAtom,
   currentSectionAtom,
   isCenterTouchedAtom,
+  navAtom,
   percentageAtom,
 } from "./atoms";
+import { mapSectionHrefToNavItem } from "./utils/nav";
 
 import { Slider } from "#/components/ui/slider";
 import { cn } from "#/lib/utils";
@@ -18,14 +19,15 @@ import truncate from "#/utils/truncate";
 
 const MAX_SECTION_LENGTH = 25;
 
-const usePage = (book: Book | null) => {
+const usePage = () => {
   const currentSection = useAtomValue(currentSectionAtom);
   const currentLocation = useAtomValue(currentLocationAtom);
+  const nav = useAtomValue(navAtom);
 
-  if (!book || !currentSection || !currentLocation)
+  if (!nav || !currentSection || !currentLocation)
     return { currentTocLabel: null, currentPage: null, totalPages: null };
 
-  const currentNavItem = book.navigation.get(currentSection.href);
+  const currentNavItem = mapSectionHrefToNavItem(nav, currentSection.href);
 
   const currentTocLabel = truncate(
     currentNavItem?.label || "",
@@ -39,7 +41,7 @@ const usePage = (book: Book | null) => {
 
 function ReaderPageProgress() {
   const book = useAtomValue(bookAtom);
-  const { currentTocLabel, currentPage, totalPages } = usePage(book);
+  const { currentTocLabel, currentPage, totalPages } = usePage();
   const [isProgressBarOpen, setProgressBarOpen] = useAtom(isCenterTouchedAtom);
   const percentage = useAtomValue(percentageAtom);
 

--- a/apps/web/src/routes/kiwi/-reader/page-progress.tsx
+++ b/apps/web/src/routes/kiwi/-reader/page-progress.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { useAtom, useAtomValue } from "@bookiwi/jotai";
 
 import { bookAtom, isCenterTouchedAtom, percentageAtom } from "./atoms";
-import { usePage } from "./hooks";
 
 import { Slider } from "#/components/ui/slider";
 import { cn } from "#/lib/utils";
@@ -13,7 +12,6 @@ function ReaderPageProgress() {
   const book = useAtomValue(bookAtom);
   const [isProgressBarOpen, setProgressBarOpen] = useAtom(isCenterTouchedAtom);
   const percentage = useAtomValue(percentageAtom);
-  const { currentTocLabel, currentPage, totalPages } = usePage();
 
   const throttledDisplay = useMemo(() => {
     if (!book) return null;
@@ -38,13 +36,7 @@ function ReaderPageProgress() {
           isProgressBarOpen ? "opacity-100" : "opacity-0",
         )}
       >
-        <div className="flex size-full justify-between text-sm text-black">
-          <div>
-            <span>{currentTocLabel || "이번 챕터"}</span>
-            <span>
-              {currentPage && totalPages ? ` ${currentPage}/${totalPages}` : ""}
-            </span>
-          </div>
+        <div className="flex size-full justify-end text-sm text-black">
           <span>{`${percentage}%`}</span>
         </div>
         {percentage !== null && (

--- a/apps/web/src/routes/kiwi/-reader/page-progress.tsx
+++ b/apps/web/src/routes/kiwi/-reader/page-progress.tsx
@@ -2,48 +2,18 @@ import { useMemo } from "react";
 
 import { useAtom, useAtomValue } from "@bookiwi/jotai";
 
-import {
-  bookAtom,
-  currentLocationAtom,
-  currentSectionAtom,
-  isCenterTouchedAtom,
-  navAtom,
-  percentageAtom,
-} from "./atoms";
-import { mapSectionHrefToNavItem } from "./utils/nav";
+import { bookAtom, isCenterTouchedAtom, percentageAtom } from "./atoms";
+import { usePage } from "./hooks";
 
 import { Slider } from "#/components/ui/slider";
 import { cn } from "#/lib/utils";
 import { throttle } from "#/utils/throttle";
-import truncate from "#/utils/truncate";
-
-const MAX_SECTION_LENGTH = 25;
-
-const usePage = () => {
-  const currentSection = useAtomValue(currentSectionAtom);
-  const currentLocation = useAtomValue(currentLocationAtom);
-  const nav = useAtomValue(navAtom);
-
-  if (!nav || !currentSection || !currentLocation)
-    return { currentTocLabel: null, currentPage: null, totalPages: null };
-
-  const currentNavItem = mapSectionHrefToNavItem(nav, currentSection.href);
-
-  const currentTocLabel = truncate(
-    currentNavItem?.label || "",
-    MAX_SECTION_LENGTH,
-  );
-  const { page: currentPage, total: totalPages } = currentLocation.start
-    .displayed || { page: 0, total: 0 };
-
-  return { currentTocLabel, currentPage, totalPages };
-};
 
 function ReaderPageProgress() {
   const book = useAtomValue(bookAtom);
-  const { currentTocLabel, currentPage, totalPages } = usePage();
   const [isProgressBarOpen, setProgressBarOpen] = useAtom(isCenterTouchedAtom);
   const percentage = useAtomValue(percentageAtom);
+  const { currentTocLabel, currentPage, totalPages } = usePage();
 
   const throttledDisplay = useMemo(() => {
     if (!book) return null;

--- a/apps/web/src/routes/kiwi/-reader/provider.tsx
+++ b/apps/web/src/routes/kiwi/-reader/provider.tsx
@@ -13,6 +13,7 @@ import {
   participantAtom,
   kiwiAtom,
   navAtom,
+  sectionsAtom,
 } from "./atoms";
 
 import { EpubIDBData, KiwiIDBData, ParticipantIDBData } from "#/types/idb";
@@ -43,6 +44,7 @@ function ReaderProvider({
     readerStore.set(currentSectionAtom, undefined);
     readerStore.set(currentLocationAtom, undefined);
     readerStore.set(navAtom, kiwiData.bookMetadata.toc);
+    readerStore.set(sectionsAtom, []);
     return readerStore;
   }, [kiwiData, participantData]);
 
@@ -57,9 +59,12 @@ function ReaderProvider({
 
         // 책 내용 검색 기능을 위한 코드
         epubBook.locations.load(epubData.locations);
-        epubBook.spine.each((section: Section) =>
-          section.load(epubBook.load.bind(epubBook)),
-        );
+        const sections: Section[] = [];
+        epubBook.spine.each((section: Section) => {
+          section.load(epubBook.load.bind(epubBook));
+          sections.push(section);
+        });
+        store.set(sectionsAtom, sections);
 
         store.set(bookAtom, epubBook);
       } catch (error) {

--- a/apps/web/src/routes/kiwi/-reader/provider.tsx
+++ b/apps/web/src/routes/kiwi/-reader/provider.tsx
@@ -12,6 +12,7 @@ import {
   isCenterTouchedAtom,
   participantAtom,
   kiwiAtom,
+  navAtom,
 } from "./atoms";
 
 import { EpubIDBData, KiwiIDBData, ParticipantIDBData } from "#/types/idb";
@@ -41,6 +42,7 @@ function ReaderProvider({
     readerStore.set(participantAtom, participantData);
     readerStore.set(currentSectionAtom, undefined);
     readerStore.set(currentLocationAtom, undefined);
+    readerStore.set(navAtom, kiwiData.bookMetadata.toc);
     return readerStore;
   }, [kiwiData, participantData]);
 

--- a/apps/web/src/routes/kiwi/-reader/utils/nav.ts
+++ b/apps/web/src/routes/kiwi/-reader/utils/nav.ts
@@ -1,0 +1,48 @@
+import { NavItem } from "@bookiwi/epubjs";
+
+export const mapSectionHrefToNavItem = (
+  navItems: NavItem[],
+  sectionHref: string,
+) => {
+  let targetNavItem: NavItem | undefined;
+
+  const searchInNavItem = (navItem: NavItem): boolean => {
+    let found = false;
+    dfs(navItem, (nav) => {
+      if (found) return;
+      // sectionHref와 일치하는 href를 가진 NavItem을 찾는다.
+      if (compareHref(sectionHref, nav.href)) {
+        targetNavItem ??= nav;
+        found = true;
+      }
+    });
+    return found;
+  };
+
+  navItems.some(searchInNavItem);
+
+  return targetNavItem;
+};
+
+export function compareHref(sectionHref: string, navItemHref: string): boolean {
+  // 빈 문자열이나 undefined 처리
+  if (!sectionHref || !navItemHref) return false;
+
+  // navItemHref에서 fragment(#) 부분 제거
+  const cleanNavItemHref = navItemHref.split("#")[0];
+
+  // 빈 문자열 처리
+  if (!cleanNavItemHref) return false;
+
+  // 정확한 매칭 또는 양방향 endsWith 비교
+  return (
+    sectionHref === cleanNavItemHref ||
+    sectionHref.endsWith(cleanNavItemHref) ||
+    cleanNavItemHref.endsWith(sectionHref)
+  );
+}
+
+export function dfs(nav: NavItem, fn: (nav: NavItem) => void) {
+  fn(nav);
+  nav.subitems?.forEach((child) => dfs(child, fn));
+}

--- a/apps/web/src/routes/my-kiwis/-apis/get-kiwis.ts
+++ b/apps/web/src/routes/my-kiwis/-apis/get-kiwis.ts
@@ -1,4 +1,4 @@
-import { IDBStore, SAMPLE_KIWI_DATA_ID } from "#/constants/idb";
+import { IDBStore } from "#/constants/idb";
 import idb from "#/managers/idb";
 import { KiwiIDBData } from "#/types/idb";
 import { Kiwi } from "#/types/kiwi";
@@ -16,11 +16,7 @@ const getKiwisFromIDB = async (): Promise<Kiwi[]> => {
       return [];
     }
 
-    // 유효한 키위 데이터만 필터링
-    const validKiwiData = kiwiStoreData.filter(
-      (kiwiItem) => kiwiItem.id !== SAMPLE_KIWI_DATA_ID,
-    );
-    const kiwis = await Promise.all(validKiwiData.map(kiwIDBDataToKiwi));
+    const kiwis = await Promise.all(kiwiStoreData.map(kiwIDBDataToKiwi));
 
     return kiwis;
   } catch (error) {


### PR DESCRIPTION
- sections, navItems atom 생성해  계산하던 로직을 최적화
- 하나의 큰 XHTML 파일에 여러 개의 목차 항목이 있을 수 있는 경우가 있어, 섹션을 목차로 생각하고 작성했던 코드를 삭제
- 그에 따라 progress bar에 페이지 정보는 삭제
- 섹션과 목차가 일치할 경우만 보고 있는 사이드바에서 현재 목차를 다른 색으로 확인할 수 있음