### PR TITLE
feat: 가상스크롤 제작 (모달목차)

### DIFF
--- a/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
+++ b/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
@@ -8,6 +8,7 @@ interface FlattenedTocItem extends NavItem {
   isExpanded?: boolean;
   hasChildren: boolean;
   parentIndex?: number;
+  numbering: string; // string으로 확정
 }
 
 interface UseVirtualizedTocProps {
@@ -26,18 +27,24 @@ export function useVirtualizedToc({
   const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
   const [scrollTop, setScrollTop] = useState(0);
 
-  // 트리를 평면화하는 함수
+  // 🎯 트리를 평면화하는 함수 (numbering 포함)
   const flattenToc = useMemo(() => {
     const flattenItems = (
       items: NavItem[],
       level = 0,
       parentIndex?: number,
+      parentNumbering = "", // 부모 번호
     ): FlattenedTocItem[] => {
       const result: FlattenedTocItem[] = [];
 
-      items.forEach((item) => {
+      items.forEach((item, index) => {
         const currentIndex = result.length;
-        const hasChildren = Boolean(item.subitems && item.subitems.length > 0); // Boolean으로 명시적 변환
+        const hasChildren = Boolean(item.subitems && item.subitems.length > 0);
+
+        // 🚀 numbering 계산
+        const numbering = parentNumbering
+          ? `${parentNumbering}.${index + 1}`
+          : `${index + 1}`;
 
         const flatItem: FlattenedTocItem = {
           ...item,
@@ -45,6 +52,7 @@ export function useVirtualizedToc({
           index: currentIndex,
           hasChildren,
           parentIndex,
+          numbering, // 추가!
           isExpanded: expandedByDefault || expandedItems.has(currentIndex),
         };
 
@@ -59,6 +67,7 @@ export function useVirtualizedToc({
             item.subitems!,
             level + 1,
             currentIndex,
+            numbering, // 부모 numbering 전달
           );
           result.push(...children);
         }
@@ -114,3 +123,5 @@ export function useVirtualizedToc({
     totalItems: flattenToc.length,
   };
 }
+
+export type { FlattenedTocItem, UseVirtualizedTocProps };

--- a/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
+++ b/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 
 import { NavItem } from "@bookiwi/epubjs/types/navigation";
 
@@ -18,6 +18,92 @@ interface UseVirtualizedTocProps {
   expandedByDefault?: boolean;
 }
 
+// 캐시를 위한 WeakMap - toc 구조별로 기본 평면화 결과 저장
+const tocCache = new WeakMap<NavItem[], FlattenedTocItem[]>();
+
+// 기본 구조 평면화 (확장 상태 무관)
+function createBaseFlatStructure(
+  items: NavItem[],
+  level = 0,
+  parentIndex?: number,
+  parentNumbering = "",
+): FlattenedTocItem[] {
+  const result: FlattenedTocItem[] = [];
+
+  items.forEach((item, index) => {
+    const currentIndex = result.length;
+    const hasChildren = Boolean(item.subitems && item.subitems.length > 0);
+    const numbering = parentNumbering
+      ? `${parentNumbering}.${index + 1}`
+      : `${index + 1}`;
+
+    const flatItem: FlattenedTocItem = {
+      ...item,
+      level,
+      index: currentIndex,
+      hasChildren,
+      parentIndex,
+      numbering,
+    };
+
+    result.push(flatItem);
+
+    // 자식이 있으면 모든 자식을 재귀적으로 추가 (확장 상태 무관)
+    if (hasChildren) {
+      const children = createBaseFlatStructure(
+        item.subitems!,
+        level + 1,
+        currentIndex,
+        numbering,
+      );
+      result.push(...children);
+    }
+  });
+
+  return result;
+}
+
+// 확장 상태에 따라 필터링
+function filterByExpandedState(
+  baseStructure: FlattenedTocItem[],
+  expandedItems: Set<number>,
+  expandedByDefault: boolean,
+): FlattenedTocItem[] {
+  const result: FlattenedTocItem[] = [];
+  const skipLevels = new Set<number>();
+
+  baseStructure.forEach((item) => {
+    // 현재 레벨보다 깊은 레벨의 스킵 정보 정리
+    const levelsToDelete = Array.from(skipLevels).filter(
+      (level) => level >= item.level,
+    );
+    levelsToDelete.forEach((level) => skipLevels.delete(level));
+
+    // 부모가 접혀있으면 스킵
+    if (skipLevels.has(item.level)) {
+      return;
+    }
+
+    const isExpanded = expandedByDefault || expandedItems.has(item.index);
+    const newItem: FlattenedTocItem = {
+      ...item,
+      level: item.level, // 명시적으로 level 포함
+      hasChildren: item.hasChildren, // 명시적으로 hasChildren 포함
+      index: result.length, // 새로운 인덱스 할당
+      isExpanded,
+    };
+
+    result.push(newItem);
+
+    // 자식이 있지만 접혀있으면 자식들을 스킵하도록 설정
+    if (item.hasChildren && !isExpanded) {
+      skipLevels.add(item.level + 1);
+    }
+  });
+
+  return result;
+}
+
 export function useVirtualizedToc({
   toc,
   itemHeight = 40,
@@ -27,60 +113,30 @@ export function useVirtualizedToc({
   const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
   const [scrollTop, setScrollTop] = useState(0);
 
-  // 트리를 평면화하는 함수
-  const flattenToc = useMemo(() => {
-    const flattenItems = (
-      items: NavItem[],
-      level = 0,
-      parentIndex?: number,
-      parentNumbering = "", // 부모 번호
-    ): FlattenedTocItem[] => {
-      const result: FlattenedTocItem[] = [];
+  // 기본 평면화 구조 캐싱
+  const baseStructure = useMemo(() => {
+    // 캐시에서 확인
+    let cached = tocCache.get(toc);
 
-      items.forEach((item, index) => {
-        const currentIndex = result.length;
-        const hasChildren = Boolean(item.subitems && item.subitems.length > 0);
+    if (!cached) {
+      // 캐시에 없으면 새로 계산하고 저장
+      cached = createBaseFlatStructure(toc);
+      tocCache.set(toc, cached);
+    }
 
-        const numbering = parentNumbering
-          ? `${parentNumbering}.${index + 1}`
-          : `${index + 1}`;
+    return cached;
+  }, [toc]);
 
-        const flatItem: FlattenedTocItem = {
-          ...item,
-          level,
-          index: currentIndex,
-          hasChildren,
-          parentIndex,
-          numbering,
-          isExpanded: expandedByDefault || expandedItems.has(currentIndex),
-        };
-
-        result.push(flatItem);
-
-        // 자식이 있고 확장된 상태라면 자식들도 추가
-        if (
-          hasChildren &&
-          (expandedByDefault || expandedItems.has(currentIndex))
-        ) {
-          const children = flattenItems(
-            item.subitems!,
-            level + 1,
-            currentIndex,
-            numbering, // 부모 numbering 전달
-          );
-          result.push(...children);
-        }
-      });
-
-      return result;
-    };
-
-    return flattenItems(toc);
-  }, [toc, expandedItems, expandedByDefault]);
+  // 확장 상태에 따른 최종 평면화 (확장 상태가 변경될 때만 재계산)
+  const flattenToc = useMemo(
+    () =>
+      filterByExpandedState(baseStructure, expandedItems, expandedByDefault),
+    [baseStructure, expandedItems, expandedByDefault],
+  );
 
   // 가상 스크롤 계산
   const virtualItems = useMemo(() => {
-    const visibleItemCount = Math.ceil(containerHeight / itemHeight) + 2; // 버퍼 추가
+    const visibleItemCount = Math.ceil(containerHeight / itemHeight) + 2;
     const startIndex = Math.floor(scrollTop / itemHeight);
     const endIndex = Math.min(startIndex + visibleItemCount, flattenToc.length);
 
@@ -94,7 +150,7 @@ export function useVirtualizedToc({
   }, [flattenToc, scrollTop, itemHeight, containerHeight]);
 
   // 항목 확장/축소 토글
-  const toggleExpand = (index: number) => {
+  const toggleExpand = useCallback((index: number) => {
     setExpandedItems((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(index)) {
@@ -104,13 +160,12 @@ export function useVirtualizedToc({
       }
       return newSet;
     });
-  };
+  }, []);
 
-  // 푸후 무한 스크롤을 위한 페이지네이션 (필요시)
-  const loadMoreItems = () => {
-    // 실제 API 호출이 있다면 여기서 구현
+  // 무한 스크롤을 위한 페이지네이션
+  const loadMoreItems = useCallback(() => {
     console.log("Load more items...");
-  };
+  }, []);
 
   return {
     virtualItems,

--- a/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
+++ b/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
@@ -8,7 +8,7 @@ interface FlattenedTocItem extends NavItem {
   isExpanded?: boolean;
   hasChildren: boolean;
   parentIndex?: number;
-  numbering: string; // string으로 확정
+  numbering: string;
 }
 
 interface UseVirtualizedTocProps {
@@ -27,7 +27,7 @@ export function useVirtualizedToc({
   const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
   const [scrollTop, setScrollTop] = useState(0);
 
-  // 🎯 트리를 평면화하는 함수 (numbering 포함)
+  // 트리를 평면화하는 함수
   const flattenToc = useMemo(() => {
     const flattenItems = (
       items: NavItem[],
@@ -41,7 +41,6 @@ export function useVirtualizedToc({
         const currentIndex = result.length;
         const hasChildren = Boolean(item.subitems && item.subitems.length > 0);
 
-        // 🚀 numbering 계산
         const numbering = parentNumbering
           ? `${parentNumbering}.${index + 1}`
           : `${index + 1}`;
@@ -52,7 +51,7 @@ export function useVirtualizedToc({
           index: currentIndex,
           hasChildren,
           parentIndex,
-          numbering, // 추가!
+          numbering,
           isExpanded: expandedByDefault || expandedItems.has(currentIndex),
         };
 
@@ -107,7 +106,7 @@ export function useVirtualizedToc({
     });
   };
 
-  // 무한 스크롤을 위한 페이지네이션 (필요시)
+  // 푸후 무한 스크롤을 위한 페이지네이션 (필요시)
   const loadMoreItems = () => {
     // 실제 API 호출이 있다면 여기서 구현
     console.log("Load more items...");

--- a/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
+++ b/apps/web/src/components/virtual-toc/hooks/useVirtualizedToc.ts
@@ -1,0 +1,116 @@
+import { useState, useMemo } from "react";
+
+import { NavItem } from "@bookiwi/epubjs/types/navigation";
+
+interface FlattenedTocItem extends NavItem {
+  level: number;
+  index: number;
+  isExpanded?: boolean;
+  hasChildren: boolean;
+  parentIndex?: number;
+}
+
+interface UseVirtualizedTocProps {
+  toc: NavItem[];
+  itemHeight?: number;
+  containerHeight?: number;
+  expandedByDefault?: boolean;
+}
+
+export function useVirtualizedToc({
+  toc,
+  itemHeight = 40,
+  containerHeight = 400,
+  expandedByDefault = false,
+}: UseVirtualizedTocProps) {
+  const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
+  const [scrollTop, setScrollTop] = useState(0);
+
+  // 트리를 평면화하는 함수
+  const flattenToc = useMemo(() => {
+    const flattenItems = (
+      items: NavItem[],
+      level = 0,
+      parentIndex?: number,
+    ): FlattenedTocItem[] => {
+      const result: FlattenedTocItem[] = [];
+
+      items.forEach((item) => {
+        const currentIndex = result.length;
+        const hasChildren = Boolean(item.subitems && item.subitems.length > 0); // Boolean으로 명시적 변환
+
+        const flatItem: FlattenedTocItem = {
+          ...item,
+          level,
+          index: currentIndex,
+          hasChildren,
+          parentIndex,
+          isExpanded: expandedByDefault || expandedItems.has(currentIndex),
+        };
+
+        result.push(flatItem);
+
+        // 자식이 있고 확장된 상태라면 자식들도 추가
+        if (
+          hasChildren &&
+          (expandedByDefault || expandedItems.has(currentIndex))
+        ) {
+          const children = flattenItems(
+            item.subitems!,
+            level + 1,
+            currentIndex,
+          );
+          result.push(...children);
+        }
+      });
+
+      return result;
+    };
+
+    return flattenItems(toc);
+  }, [toc, expandedItems, expandedByDefault]);
+
+  // 가상 스크롤 계산
+  const virtualItems = useMemo(() => {
+    const visibleItemCount = Math.ceil(containerHeight / itemHeight) + 2; // 버퍼 추가
+    const startIndex = Math.floor(scrollTop / itemHeight);
+    const endIndex = Math.min(startIndex + visibleItemCount, flattenToc.length);
+
+    return {
+      items: flattenToc.slice(startIndex, endIndex),
+      startIndex,
+      endIndex,
+      totalHeight: flattenToc.length * itemHeight,
+      offsetY: startIndex * itemHeight,
+    };
+  }, [flattenToc, scrollTop, itemHeight, containerHeight]);
+
+  // 항목 확장/축소 토글
+  const toggleExpand = (index: number) => {
+    setExpandedItems((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(index)) {
+        newSet.delete(index);
+      } else {
+        newSet.add(index);
+      }
+      return newSet;
+    });
+  };
+
+  // 무한 스크롤을 위한 페이지네이션 (필요시)
+  const loadMoreItems = () => {
+    // 실제 API 호출이 있다면 여기서 구현
+    console.log("Load more items...");
+  };
+
+  return {
+    virtualItems,
+    flattenToc,
+    scrollTop,
+    setScrollTop,
+    toggleExpand,
+    loadMoreItems,
+    totalItems: flattenToc.length,
+  };
+}

--- a/apps/web/src/components/virtual-toc/index.ts
+++ b/apps/web/src/components/virtual-toc/index.ts
@@ -1,0 +1,4 @@
+export { VirtualizedToc } from "./virtualized-toc";
+export { VirtualizedTocItem } from "./virtualized-toc-item";
+export { SimpleVirtualizedToc } from "./simple-virtualized-toc";
+export { useVirtualizedToc } from "./hooks/useVirtualizedToc";

--- a/apps/web/src/components/virtual-toc/simple-virtualized-toc.tsx
+++ b/apps/web/src/components/virtual-toc/simple-virtualized-toc.tsx
@@ -1,0 +1,193 @@
+import { Book, ChevronRight, ChevronDown } from "lucide-react";
+import { useCallback, useRef, useState, useMemo } from "react";
+
+import { NavItem } from "@bookiwi/epubjs/types/navigation";
+
+// 평면화된 목차 아이템 타입
+interface FlatTocItem extends NavItem {
+  level: number;
+  index: number;
+  numbering: string;
+  isExpanded?: boolean;
+  hasChildren: boolean;
+}
+
+interface SimpleVirtualizedTocProps {
+  toc: NavItem[];
+  maxHeight?: number;
+  itemHeight?: number;
+  onNavigate?: (href: string) => void;
+}
+
+export function SimpleVirtualizedToc({
+  toc,
+  maxHeight = 240,
+  itemHeight = 32,
+  onNavigate,
+}: SimpleVirtualizedTocProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
+
+  // 목차를 평면화하는 함수
+  const flattenedToc = useMemo(() => {
+    const flattenItems = (
+      items: NavItem[],
+      level = 0,
+      parentNumbering = "",
+    ): FlatTocItem[] => {
+      const result: FlatTocItem[] = [];
+
+      items.forEach((item, index) => {
+        const currentIndex = result.length;
+        const numbering = parentNumbering
+          ? `${parentNumbering}.${index + 1}`
+          : `${index + 1}`;
+        const hasChildren = Boolean(item.subitems?.length);
+
+        const flatItem: FlatTocItem = {
+          ...item,
+          level,
+          index: currentIndex,
+          numbering,
+          hasChildren,
+          isExpanded: expandedItems.has(currentIndex),
+        };
+
+        result.push(flatItem);
+
+        // 확장된 상태이고 자식이 있으면 자식들도 추가
+        if (hasChildren && expandedItems.has(currentIndex)) {
+          const children = flattenItems(item.subitems!, level + 1, numbering);
+          result.push(...children);
+        }
+      });
+
+      return result;
+    };
+
+    return flattenItems(toc);
+  }, [toc, expandedItems]);
+
+  // 가상 스크롤 계산
+  const virtualItems = useMemo(() => {
+    const visibleItemCount = Math.ceil(maxHeight / itemHeight) + 2;
+    const startIndex = Math.floor(scrollTop / itemHeight);
+    const endIndex = Math.min(
+      startIndex + visibleItemCount,
+      flattenedToc.length,
+    );
+
+    return {
+      items: flattenedToc.slice(startIndex, endIndex),
+      startIndex,
+      endIndex,
+      totalHeight: flattenedToc.length * itemHeight,
+      offsetY: startIndex * itemHeight,
+    };
+  }, [flattenedToc, scrollTop, itemHeight, maxHeight]);
+
+  // 스크롤 핸들러
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLDivElement;
+    setScrollTop(target.scrollTop);
+  }, []);
+
+  // 확장/축소 토글
+  const toggleExpand = useCallback((index: number) => {
+    setExpandedItems((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(index)) {
+        newSet.delete(index);
+      } else {
+        newSet.add(index);
+      }
+      return newSet;
+    });
+  }, []);
+
+  // 네비게이션 핸들러
+  const handleNavigate = useCallback(
+    (href: string) => {
+      if (onNavigate) {
+        onNavigate(href);
+      }
+    },
+    [onNavigate],
+  );
+
+  if (!toc || toc.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-center">
+        <Book className="mb-2 size-8 text-gray-400" />
+        <p className="text-sm text-gray-600">목차가 없습니다</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollContainerRef}
+      className="overflow-y-auto pr-1"
+      style={{ maxHeight }}
+      onScroll={handleScroll}
+    >
+      {/* 전체 높이를 위한 컨테이너 */}
+      <div style={{ height: virtualItems.totalHeight, position: "relative" }}>
+        {/* 가상화된 아이템들만 렌더링 */}
+        <div
+          style={{
+            transform: `translateY(${virtualItems.offsetY}px)`,
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+          }}
+        >
+          {virtualItems.items.map((item) => (
+            /* eslint-disable */
+            <div
+              key={`${item.id || item.href}-${item.index}`}
+              className="py-1"
+              style={{ height: itemHeight }}
+            >
+              <div
+                className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-muted"
+                style={{ paddingLeft: `${item.level * 16 + 8}px` }}
+                onClick={() => handleNavigate(item.href)}
+              >
+                {/* 확장/축소 버튼 */}
+                {item.hasChildren && (
+                  <button
+                    type="button"
+                    className="mr-1 rounded p-0.5 hover:bg-gray-200"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleExpand(item.index);
+                    }}
+                  >
+                    {item.isExpanded ? (
+                      <ChevronDown size={12} />
+                    ) : (
+                      <ChevronRight size={12} />
+                    )}
+                  </button>
+                )}
+
+                {/* 번호 */}
+                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+                  {item.numbering}
+                </span>
+
+                {/* 제목 */}
+                <span className="truncate text-sm group-hover:text-primary">
+                  {item.label}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/virtual-toc/simple-virtualized-toc.tsx
+++ b/apps/web/src/components/virtual-toc/simple-virtualized-toc.tsx
@@ -1,9 +1,6 @@
-import { Book, ChevronRight, ChevronDown } from "lucide-react";
-import { useCallback, useRef } from "react";
-
 import { NavItem } from "@bookiwi/epubjs/types/navigation";
 
-import { useVirtualizedToc } from "./hooks/useVirtualizedToc";
+import { VirtualizedToc } from "./virtualized-toc";
 
 interface SimpleVirtualizedTocProps {
   toc: NavItem[];
@@ -11,119 +8,9 @@ interface SimpleVirtualizedTocProps {
   itemHeight?: number;
   onNavigate?: (href: string) => void;
   expandedByDefault?: boolean;
+  showNumbering?: boolean;
 }
 
-export function SimpleVirtualizedToc({
-  toc,
-  maxHeight = 240,
-  itemHeight = 32,
-  onNavigate,
-  expandedByDefault = false,
-}: SimpleVirtualizedTocProps) {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  const { virtualItems, setScrollTop, toggleExpand } = useVirtualizedToc({
-    toc,
-    itemHeight,
-    containerHeight: maxHeight,
-    expandedByDefault,
-  });
-
-  // 🎯 메모이제이션된 핸들러들
-  const handleScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const target = e.target as HTMLDivElement;
-      setScrollTop(target.scrollTop);
-    },
-    [setScrollTop],
-  );
-
-  const handleNavigate = useCallback(
-    (href: string) => {
-      if (onNavigate) {
-        onNavigate(href);
-      }
-    },
-    [onNavigate],
-  );
-
-  const handleToggleExpand = useCallback(
-    (e: React.MouseEvent, index: number) => {
-      e.stopPropagation();
-      toggleExpand(index);
-    },
-    [toggleExpand],
-  );
-
-  if (!toc || toc.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-6 text-center">
-        <Book className="mb-2 size-8 text-gray-400" />
-        <p className="text-sm text-gray-600">목차가 없습니다</p>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      ref={scrollContainerRef}
-      className="overflow-y-auto pr-1"
-      style={{ maxHeight }}
-      onScroll={handleScroll}
-    >
-      {/* 전체 높이를 위한 컨테이너 */}
-      <div style={{ height: virtualItems.totalHeight, position: "relative" }}>
-        {/* 가상화된 아이템들만 렌더링 */}
-        <div
-          style={{
-            transform: `translateY(${virtualItems.offsetY}px)`,
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-          }}
-        >
-          {virtualItems.items.map((item) => (
-            /*eslint-disable*/
-            <div
-              key={`${item.id || item.href}-${item.index}`}
-              className="py-1"
-              style={{ height: itemHeight }}
-            >
-              <div
-                className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-muted"
-                style={{ paddingLeft: `${item.level * 16 + 8}px` }}
-                onClick={() => handleNavigate(item.href)}
-              >
-                {/* 확장/축소 버튼 */}
-                {item.hasChildren && (
-                  <button
-                    type="button"
-                    className="mr-1 rounded p-0.5 hover:bg-gray-200"
-                    onClick={(e) => handleToggleExpand(e, item.index)}
-                  >
-                    {item.isExpanded ? (
-                      <ChevronDown size={12} />
-                    ) : (
-                      <ChevronRight size={12} />
-                    )}
-                  </button>
-                )}
-
-                {/* 번호 */}
-                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
-                  {item.numbering}
-                </span>
-
-                {/* 제목 */}
-                <span className="truncate text-sm group-hover:text-primary">
-                  {item.label}
-                </span>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+export function SimpleVirtualizedToc(props: SimpleVirtualizedTocProps) {
+  return <VirtualizedToc {...props} variant="simple" showTitle={false} />;
 }

--- a/apps/web/src/components/virtual-toc/simple-virtualized-toc.tsx
+++ b/apps/web/src/components/virtual-toc/simple-virtualized-toc.tsx
@@ -1,22 +1,16 @@
 import { Book, ChevronRight, ChevronDown } from "lucide-react";
-import { useCallback, useRef, useState, useMemo } from "react";
+import { useCallback, useRef } from "react";
 
 import { NavItem } from "@bookiwi/epubjs/types/navigation";
 
-// 평면화된 목차 아이템 타입
-interface FlatTocItem extends NavItem {
-  level: number;
-  index: number;
-  numbering: string;
-  isExpanded?: boolean;
-  hasChildren: boolean;
-}
+import { useVirtualizedToc } from "./hooks/useVirtualizedToc";
 
 interface SimpleVirtualizedTocProps {
   toc: NavItem[];
   maxHeight?: number;
   itemHeight?: number;
   onNavigate?: (href: string) => void;
+  expandedByDefault?: boolean;
 }
 
 export function SimpleVirtualizedToc({
@@ -24,89 +18,26 @@ export function SimpleVirtualizedToc({
   maxHeight = 240,
   itemHeight = 32,
   onNavigate,
+  expandedByDefault = false,
 }: SimpleVirtualizedTocProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [scrollTop, setScrollTop] = useState(0);
-  const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
 
-  // 목차를 평면화하는 함수
-  const flattenedToc = useMemo(() => {
-    const flattenItems = (
-      items: NavItem[],
-      level = 0,
-      parentNumbering = "",
-    ): FlatTocItem[] => {
-      const result: FlatTocItem[] = [];
+  const { virtualItems, setScrollTop, toggleExpand } = useVirtualizedToc({
+    toc,
+    itemHeight,
+    containerHeight: maxHeight,
+    expandedByDefault,
+  });
 
-      items.forEach((item, index) => {
-        const currentIndex = result.length;
-        const numbering = parentNumbering
-          ? `${parentNumbering}.${index + 1}`
-          : `${index + 1}`;
-        const hasChildren = Boolean(item.subitems?.length);
+  // 🎯 메모이제이션된 핸들러들
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLDivElement;
+      setScrollTop(target.scrollTop);
+    },
+    [setScrollTop],
+  );
 
-        const flatItem: FlatTocItem = {
-          ...item,
-          level,
-          index: currentIndex,
-          numbering,
-          hasChildren,
-          isExpanded: expandedItems.has(currentIndex),
-        };
-
-        result.push(flatItem);
-
-        // 확장된 상태이고 자식이 있으면 자식들도 추가
-        if (hasChildren && expandedItems.has(currentIndex)) {
-          const children = flattenItems(item.subitems!, level + 1, numbering);
-          result.push(...children);
-        }
-      });
-
-      return result;
-    };
-
-    return flattenItems(toc);
-  }, [toc, expandedItems]);
-
-  // 가상 스크롤 계산
-  const virtualItems = useMemo(() => {
-    const visibleItemCount = Math.ceil(maxHeight / itemHeight) + 2;
-    const startIndex = Math.floor(scrollTop / itemHeight);
-    const endIndex = Math.min(
-      startIndex + visibleItemCount,
-      flattenedToc.length,
-    );
-
-    return {
-      items: flattenedToc.slice(startIndex, endIndex),
-      startIndex,
-      endIndex,
-      totalHeight: flattenedToc.length * itemHeight,
-      offsetY: startIndex * itemHeight,
-    };
-  }, [flattenedToc, scrollTop, itemHeight, maxHeight]);
-
-  // 스크롤 핸들러
-  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLDivElement;
-    setScrollTop(target.scrollTop);
-  }, []);
-
-  // 확장/축소 토글
-  const toggleExpand = useCallback((index: number) => {
-    setExpandedItems((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(index)) {
-        newSet.delete(index);
-      } else {
-        newSet.add(index);
-      }
-      return newSet;
-    });
-  }, []);
-
-  // 네비게이션 핸들러
   const handleNavigate = useCallback(
     (href: string) => {
       if (onNavigate) {
@@ -114,6 +45,14 @@ export function SimpleVirtualizedToc({
       }
     },
     [onNavigate],
+  );
+
+  const handleToggleExpand = useCallback(
+    (e: React.MouseEvent, index: number) => {
+      e.stopPropagation();
+      toggleExpand(index);
+    },
+    [toggleExpand],
   );
 
   if (!toc || toc.length === 0) {
@@ -145,7 +84,7 @@ export function SimpleVirtualizedToc({
           }}
         >
           {virtualItems.items.map((item) => (
-            /* eslint-disable */
+            /*eslint-disable*/
             <div
               key={`${item.id || item.href}-${item.index}`}
               className="py-1"
@@ -161,10 +100,7 @@ export function SimpleVirtualizedToc({
                   <button
                     type="button"
                     className="mr-1 rounded p-0.5 hover:bg-gray-200"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      toggleExpand(item.index);
-                    }}
+                    onClick={(e) => handleToggleExpand(e, item.index)}
                   >
                     {item.isExpanded ? (
                       <ChevronDown size={12} />

--- a/apps/web/src/components/virtual-toc/virtualized-toc-item.tsx
+++ b/apps/web/src/components/virtual-toc/virtualized-toc-item.tsx
@@ -1,0 +1,86 @@
+import { ChevronDown, ChevronRight, BookOpen } from "lucide-react";
+import { memo } from "react";
+
+import { NavItem } from "@bookiwi/epubjs/types/navigation";
+
+import { cn } from "#/lib/utils";
+
+interface FlattenedTocItem extends NavItem {
+  level: number;
+  index: number;
+  isExpanded?: boolean;
+  hasChildren: boolean;
+  parentIndex?: number;
+}
+
+interface VirtualizedTocItemProps {
+  item: FlattenedTocItem;
+  onNavigate: (href: string) => void;
+  onToggleExpand: (index: number) => void;
+  isActive?: boolean;
+  style?: React.CSSProperties;
+}
+
+export const VirtualizedTocItem = memo(
+  ({
+    item,
+    onNavigate,
+    onToggleExpand,
+    isActive = false,
+    style,
+  }: VirtualizedTocItemProps) => {
+    const handleClick = () => {
+      onNavigate(item.href);
+    };
+
+    const handleToggle = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onToggleExpand(item.index);
+    };
+
+    return (
+      <div
+        style={style}
+        className={cn(
+          "group flex cursor-pointer items-center rounded-md p-2 hover:bg-gray-100",
+          isActive && "bg-gray-100",
+        )}
+        onClick={handleClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+      >
+        <div
+          style={{ paddingLeft: `${item.level * 12}px` }}
+          className="flex flex-1 items-center"
+        >
+          <BookOpen size={16} className="mr-2 shrink-0 text-gray-500" />
+
+          <span className="flex-1 truncate text-sm transition-colors group-hover:text-primary">
+            {item.label}
+          </span>
+
+          {item.hasChildren && (
+            <button
+              type="button"
+              onClick={handleToggle}
+              className="ml-2 shrink-0 rounded-full p-1 hover:bg-gray-200 focus:outline-none"
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {item.isExpanded ? (
+                <ChevronDown size={16} className="text-gray-500" />
+              ) : (
+                <ChevronRight size={16} className="text-gray-500" />
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  },
+);

--- a/apps/web/src/components/virtual-toc/virtualized-toc.tsx
+++ b/apps/web/src/components/virtual-toc/virtualized-toc.tsx
@@ -1,4 +1,4 @@
-import { BookOpen } from "lucide-react";
+import { BookOpen, Book, ChevronRight, ChevronDown } from "lucide-react";
 import { useCallback, useRef, useEffect, useMemo } from "react";
 
 import { NavItem } from "@bookiwi/epubjs/types/navigation";
@@ -10,16 +10,23 @@ import { VirtualizedTocItem } from "./virtualized-toc-item";
 import { bookAtom, currentSectionAtom } from "#/routes/kiwi/-reader/atoms";
 
 interface VirtualizedTocProps {
-  toc?: NavItem[]; // 직접 toc 전달 가능
-  book?: any; // 직접 book 전달 가능
-  currentHref?: string; // 현재 위치 직접 전달 가능
-  onNavigate?: (href: string) => void; // 네비게이션 콜백
+  // 🎯 데이터 관련
+  toc?: NavItem[];
+  book?: any;
+  currentHref?: string;
+  onNavigate?: (href: string) => void;
 
-  // 기존 props
+  // 🎯 UI 설정
   containerHeight?: number;
+  maxHeight?: number; // SimpleVirtualizedToc 호환성을 위해 추가
   itemHeight?: number;
   className?: string;
   expandedByDefault?: boolean;
+
+  // 🎯 렌더링 모드
+  variant?: "full" | "simple"; // full: VirtualizedTocItem 사용, simple: 인라인 렌더링
+  showTitle?: boolean; // 제목 표시 여부
+  showNumbering?: boolean; // 번호 표시 여부
 }
 
 export function VirtualizedToc({
@@ -27,23 +34,30 @@ export function VirtualizedToc({
   book: propBook,
   currentHref: propCurrentHref,
   onNavigate,
-  containerHeight = 400,
+  containerHeight,
+  maxHeight,
   itemHeight = 40,
   className = "",
   expandedByDefault = false,
+  variant = "full",
+  showTitle = true,
+  showNumbering = true,
 }: VirtualizedTocProps) {
-  // 🎯 props 우선, 없으면 atom 사용 (EPUB 리더에서)
+  // 🎯 높이 설정 (maxHeight 우선, 없으면 containerHeight)
+  const finalHeight = maxHeight || containerHeight || 400;
+
+  // 🎯 Atom 데이터 (variant가 "full"일 때만)
   const atomBook = useAtomValue(bookAtom);
   const atomCurrentSection = useAtomValue(currentSectionAtom);
 
-  const book = propBook || atomBook;
+  const book = propBook || (variant === "full" ? atomBook : null);
   const toc = propToc || book?.navigation?.toc || [];
 
-  // ✅ useMemo로 currentSection 메모이제이션
-  const currentSection = useMemo(
-    () => (propCurrentHref ? { href: propCurrentHref } : atomCurrentSection),
-    [propCurrentHref, atomCurrentSection],
-  );
+  // 🎯 현재 섹션 메모이제이션 (variant가 "full"일 때만)
+  const currentSection = useMemo(() => {
+    if (variant === "simple") return null;
+    return propCurrentHref ? { href: propCurrentHref } : atomCurrentSection;
+  }, [propCurrentHref, atomCurrentSection, variant]);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -51,42 +65,51 @@ export function VirtualizedToc({
     useVirtualizedToc({
       toc,
       itemHeight,
-      containerHeight,
+      containerHeight: finalHeight,
       expandedByDefault,
     });
 
-  // 목차 항목 클릭 핸들러
+  // 🎯 통합된 네비게이션 핸들러
   const handleNavClick = useCallback(
     (href: string) => {
       if (onNavigate) {
-        // 커스텀 네비게이션 콜백 사용
         onNavigate(href);
       } else if (book?.rendition) {
-        // EPUB 리더 기본 네비게이션
         book.rendition.display(href);
       }
     },
     [book, onNavigate],
   );
 
-  // 스크롤 핸들러
+  // 🎯 통합된 스크롤 핸들러
   const handleScroll = useCallback(
     (e: React.UIEvent<HTMLDivElement>) => {
       const target = e.target as HTMLDivElement;
       setScrollTop(target.scrollTop);
 
-      // 무한 스크롤 트리거 (하단 근처에서)
-      const { scrollTop, scrollHeight, clientHeight } = target;
-      if (scrollHeight - scrollTop - clientHeight < 100) {
-        loadMoreItems();
+      // 무한 스크롤 (variant가 "full"일 때만)
+      if (variant === "full") {
+        const { scrollTop, scrollHeight, clientHeight } = target;
+        if (scrollHeight - scrollTop - clientHeight < 100) {
+          loadMoreItems();
+        }
       }
     },
-    [setScrollTop, loadMoreItems],
+    [setScrollTop, loadMoreItems, variant],
   );
 
-  // 현재 섹션 자동 스크롤
+  // 🎯 확장/축소 핸들러 (simple variant용)
+  const handleToggleExpand = useCallback(
+    (e: React.MouseEvent, index: number) => {
+      e.stopPropagation();
+      toggleExpand(index);
+    },
+    [toggleExpand],
+  );
+
+  // 🎯 현재 섹션 자동 스크롤 (variant가 "full"일 때만)
   useEffect(() => {
-    if (currentSection && scrollContainerRef.current) {
+    if (variant === "full" && currentSection && scrollContainerRef.current) {
       const currentIndex = virtualItems.items.findIndex(
         (item) => item.href === currentSection.href,
       );
@@ -97,34 +120,51 @@ export function VirtualizedToc({
         scrollContainerRef.current.scrollTop = targetScrollTop;
       }
     }
-  }, [currentSection, virtualItems, itemHeight]);
+  }, [currentSection, virtualItems, itemHeight, variant]);
 
-  // 로딩 상태 (toc가 없을 때)
+  // 🎯 빈 상태 처리
   if (!toc || toc.length === 0) {
+    const EmptyIcon = variant === "simple" ? Book : BookOpen;
+    const emptyMessage =
+      variant === "simple" ? "목차가 없습니다" : "목차를 불러오는 중입니다";
+    const emptySubMessage =
+      variant === "full"
+        ? "잠시만 기다려주세요. 또는 이 책에 목차가 없을 수 있습니다."
+        : null;
+
     return (
       <div className="flex flex-col items-center justify-center py-6 text-center">
-        <BookOpen className="mb-2 size-8 text-gray-400" />
-        <p className="text-sm text-gray-600">목차를 불러오는 중입니다</p>
-        <p className="text-xs text-gray-500">
-          잠시만 기다려주세요. 또는 이 책에 목차가 없을 수 있습니다.
-        </p>
+        <EmptyIcon className="mb-2 size-8 text-gray-400" />
+        <p className="text-sm text-gray-600">{emptyMessage}</p>
+        {emptySubMessage && (
+          <p className="text-xs text-gray-500">{emptySubMessage}</p>
+        )}
       </div>
     );
   }
 
   return (
     <div className={className}>
-      {!propToc && <h3 className="mb-4 text-lg font-medium">목차</h3>}
+      {/* 제목 (showTitle이 true이고 propToc가 없을 때만) */}
+      {showTitle && !propToc && (
+        <h3 className="mb-4 text-lg font-medium">목차</h3>
+      )}
 
       <div
         ref={scrollContainerRef}
-        className="relative overflow-auto"
-        style={{ height: containerHeight }}
+        className={
+          variant === "simple"
+            ? "overflow-y-auto pr-1"
+            : "relative overflow-auto"
+        }
+        style={{
+          height: variant === "simple" ? undefined : finalHeight,
+          maxHeight: variant === "simple" ? finalHeight : undefined,
+        }}
         onScroll={handleScroll}
       >
-        {/* 전체 높이를 위한 컨테이너 */}
+        {/* 🎯 통합된 가상 스크롤 컨테이너 */}
         <div style={{ height: virtualItems.totalHeight, position: "relative" }}>
-          {/* 가상화된 아이템들 */}
           <div
             style={{
               transform: `translateY(${virtualItems.offsetY}px)`,
@@ -134,25 +174,69 @@ export function VirtualizedToc({
               right: 0,
             }}
           >
-            {virtualItems.items.map((item) => (
-              <VirtualizedTocItem
-                key={`${item.id || item.href}-${item.index}`}
-                item={item}
-                onNavigate={handleNavClick}
-                onToggleExpand={toggleExpand}
-                isActive={currentSection?.href === item.href}
-                style={{
-                  height: itemHeight,
-                  display: "flex",
-                  alignItems: "center",
-                }}
-              />
-            ))}
+            {virtualItems.items.map((item) =>
+              variant === "full" ? (
+                // 🎯 Full variant: VirtualizedTocItem 사용
+                <VirtualizedTocItem
+                  key={`${item.id || item.href}-${item.index}`}
+                  item={item}
+                  onNavigate={handleNavClick}
+                  onToggleExpand={toggleExpand}
+                  isActive={currentSection?.href === item.href}
+                  style={{
+                    height: itemHeight,
+                    display: "flex",
+                    alignItems: "center",
+                  }}
+                />
+              ) : (
+                /* eslint-disable */
+                <div
+                  key={`${item.id || item.href}-${item.index}`}
+                  className="py-1"
+                  style={{ height: itemHeight }}
+                >
+                  <div
+                    className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-muted"
+                    style={{ paddingLeft: `${item.level * 16 + 8}px` }}
+                    onClick={() => handleNavClick(item.href)}
+                  >
+                    {/* 확장/축소 버튼 */}
+                    {item.hasChildren && (
+                      <button
+                        type="button"
+                        className="mr-1 rounded p-0.5 hover:bg-gray-200"
+                        onClick={(e) => handleToggleExpand(e, item.index)}
+                      >
+                        {item.isExpanded ? (
+                          <ChevronDown size={12} />
+                        ) : (
+                          <ChevronRight size={12} />
+                        )}
+                      </button>
+                    )}
+
+                    {/* 번호 */}
+                    {showNumbering && (
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+                        {item.numbering}
+                      </span>
+                    )}
+
+                    {/* 제목 */}
+                    <span className="truncate text-sm group-hover:text-primary">
+                      {item.label}
+                    </span>
+                  </div>
+                </div>
+              ),
+            )}
           </div>
         </div>
       </div>
 
-      {virtualItems.items.length === 0 && (
+      {/* 빈 아이템 상태 (variant가 "full"일 때만) */}
+      {variant === "full" && virtualItems.items.length === 0 && (
         <div className="flex flex-col items-center justify-center py-6 text-center">
           <BookOpen className="mb-2 size-8 text-gray-400" />
           <p className="text-sm text-gray-600">목차를 불러오는 중입니다</p>
@@ -163,4 +247,11 @@ export function VirtualizedToc({
       )}
     </div>
   );
+}
+
+// 🎯 SimpleVirtualizedToc를 위한 편의 함수
+export function SimpleVirtualizedToc(
+  props: Omit<VirtualizedTocProps, "variant">,
+) {
+  return <VirtualizedToc {...props} variant="simple" showTitle={false} />;
 }

--- a/apps/web/src/components/virtual-toc/virtualized-toc.tsx
+++ b/apps/web/src/components/virtual-toc/virtualized-toc.tsx
@@ -1,0 +1,166 @@
+import { BookOpen } from "lucide-react";
+import { useCallback, useRef, useEffect, useMemo } from "react";
+
+import { NavItem } from "@bookiwi/epubjs/types/navigation";
+import { useAtomValue } from "@bookiwi/jotai";
+
+import { useVirtualizedToc } from "./hooks/useVirtualizedToc";
+import { VirtualizedTocItem } from "./virtualized-toc-item";
+
+import { bookAtom, currentSectionAtom } from "#/routes/kiwi/-reader/atoms";
+
+interface VirtualizedTocProps {
+  toc?: NavItem[]; // 직접 toc 전달 가능
+  book?: any; // 직접 book 전달 가능
+  currentHref?: string; // 현재 위치 직접 전달 가능
+  onNavigate?: (href: string) => void; // 네비게이션 콜백
+
+  // 기존 props
+  containerHeight?: number;
+  itemHeight?: number;
+  className?: string;
+  expandedByDefault?: boolean;
+}
+
+export function VirtualizedToc({
+  toc: propToc,
+  book: propBook,
+  currentHref: propCurrentHref,
+  onNavigate,
+  containerHeight = 400,
+  itemHeight = 40,
+  className = "",
+  expandedByDefault = false,
+}: VirtualizedTocProps) {
+  // 🎯 props 우선, 없으면 atom 사용 (EPUB 리더에서)
+  const atomBook = useAtomValue(bookAtom);
+  const atomCurrentSection = useAtomValue(currentSectionAtom);
+
+  const book = propBook || atomBook;
+  const toc = propToc || book?.navigation?.toc || [];
+
+  // ✅ useMemo로 currentSection 메모이제이션
+  const currentSection = useMemo(
+    () => (propCurrentHref ? { href: propCurrentHref } : atomCurrentSection),
+    [propCurrentHref, atomCurrentSection],
+  );
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const { virtualItems, setScrollTop, toggleExpand, loadMoreItems } =
+    useVirtualizedToc({
+      toc,
+      itemHeight,
+      containerHeight,
+      expandedByDefault,
+    });
+
+  // 목차 항목 클릭 핸들러
+  const handleNavClick = useCallback(
+    (href: string) => {
+      if (onNavigate) {
+        // 커스텀 네비게이션 콜백 사용
+        onNavigate(href);
+      } else if (book?.rendition) {
+        // EPUB 리더 기본 네비게이션
+        book.rendition.display(href);
+      }
+    },
+    [book, onNavigate],
+  );
+
+  // 스크롤 핸들러
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLDivElement;
+      setScrollTop(target.scrollTop);
+
+      // 무한 스크롤 트리거 (하단 근처에서)
+      const { scrollTop, scrollHeight, clientHeight } = target;
+      if (scrollHeight - scrollTop - clientHeight < 100) {
+        loadMoreItems();
+      }
+    },
+    [setScrollTop, loadMoreItems],
+  );
+
+  // 현재 섹션 자동 스크롤
+  useEffect(() => {
+    if (currentSection && scrollContainerRef.current) {
+      const currentIndex = virtualItems.items.findIndex(
+        (item) => item.href === currentSection.href,
+      );
+
+      if (currentIndex !== -1) {
+        const targetScrollTop =
+          (virtualItems.startIndex + currentIndex) * itemHeight;
+        scrollContainerRef.current.scrollTop = targetScrollTop;
+      }
+    }
+  }, [currentSection, virtualItems, itemHeight]);
+
+  // 로딩 상태 (toc가 없을 때)
+  if (!toc || toc.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-center">
+        <BookOpen className="mb-2 size-8 text-gray-400" />
+        <p className="text-sm text-gray-600">목차를 불러오는 중입니다</p>
+        <p className="text-xs text-gray-500">
+          잠시만 기다려주세요. 또는 이 책에 목차가 없을 수 있습니다.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      {!propToc && <h3 className="mb-4 text-lg font-medium">목차</h3>}
+
+      <div
+        ref={scrollContainerRef}
+        className="relative overflow-auto"
+        style={{ height: containerHeight }}
+        onScroll={handleScroll}
+      >
+        {/* 전체 높이를 위한 컨테이너 */}
+        <div style={{ height: virtualItems.totalHeight, position: "relative" }}>
+          {/* 가상화된 아이템들 */}
+          <div
+            style={{
+              transform: `translateY(${virtualItems.offsetY}px)`,
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+            }}
+          >
+            {virtualItems.items.map((item) => (
+              <VirtualizedTocItem
+                key={`${item.id || item.href}-${item.index}`}
+                item={item}
+                onNavigate={handleNavClick}
+                onToggleExpand={toggleExpand}
+                isActive={currentSection?.href === item.href}
+                style={{
+                  height: itemHeight,
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {virtualItems.items.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-6 text-center">
+          <BookOpen className="mb-2 size-8 text-gray-400" />
+          <p className="text-sm text-gray-600">목차를 불러오는 중입니다</p>
+          <p className="text-xs text-gray-500">
+            잠시만 기다려주세요. 또는 이 책에 목차가 없을 수 있습니다.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/virtual-toc/virtualized-toc.tsx
+++ b/apps/web/src/components/virtual-toc/virtualized-toc.tsx
@@ -18,13 +18,13 @@ interface VirtualizedTocProps {
 
   // 🎯 UI 설정
   containerHeight?: number;
-  maxHeight?: number; // SimpleVirtualizedToc 호환성을 위해 추가
+  maxHeight?: number;
   itemHeight?: number;
   className?: string;
   expandedByDefault?: boolean;
 
   // 🎯 렌더링 모드
-  variant?: "full" | "simple"; // full: VirtualizedTocItem 사용, simple: 인라인 렌더링
+  variant?: "full" | "simple"; // full: VirtualizedTocItem 사용 추후 사이드바목차, simple: 인라인 렌더링
   showTitle?: boolean; // 제목 표시 여부
   showNumbering?: boolean; // 번호 표시 여부
 }
@@ -43,17 +43,17 @@ export function VirtualizedToc({
   showTitle = true,
   showNumbering = true,
 }: VirtualizedTocProps) {
-  // 🎯 높이 설정 (maxHeight 우선, 없으면 containerHeight)
+  // 높이 설정 (maxHeight 우선, 없으면 containerHeight)
   const finalHeight = maxHeight || containerHeight || 400;
 
-  // 🎯 Atom 데이터 (variant가 "full"일 때만)
+  // Atom 데이터 (variant가 "full"일 때만)
   const atomBook = useAtomValue(bookAtom);
   const atomCurrentSection = useAtomValue(currentSectionAtom);
 
   const book = propBook || (variant === "full" ? atomBook : null);
   const toc = propToc || book?.navigation?.toc || [];
 
-  // 🎯 현재 섹션 메모이제이션 (variant가 "full"일 때만)
+  // 현재 섹션 메모이제이션 (variant가 "full"일 때만)
   const currentSection = useMemo(() => {
     if (variant === "simple") return null;
     return propCurrentHref ? { href: propCurrentHref } : atomCurrentSection;
@@ -69,7 +69,7 @@ export function VirtualizedToc({
       expandedByDefault,
     });
 
-  // 🎯 통합된 네비게이션 핸들러
+  //  통합된 네비게이션 핸들러
   const handleNavClick = useCallback(
     (href: string) => {
       if (onNavigate) {
@@ -81,7 +81,7 @@ export function VirtualizedToc({
     [book, onNavigate],
   );
 
-  // 🎯 통합된 스크롤 핸들러
+  //  통합된 스크롤 핸들러
   const handleScroll = useCallback(
     (e: React.UIEvent<HTMLDivElement>) => {
       const target = e.target as HTMLDivElement;
@@ -98,7 +98,7 @@ export function VirtualizedToc({
     [setScrollTop, loadMoreItems, variant],
   );
 
-  // 🎯 확장/축소 핸들러 (simple variant용)
+  // 확장/축소 핸들러 (simple variant용)
   const handleToggleExpand = useCallback(
     (e: React.MouseEvent, index: number) => {
       e.stopPropagation();
@@ -107,7 +107,7 @@ export function VirtualizedToc({
     [toggleExpand],
   );
 
-  // 🎯 현재 섹션 자동 스크롤 (variant가 "full"일 때만)
+  //  현재 섹션 자동 스크롤 (variant가 "full"일 때만)
   useEffect(() => {
     if (variant === "full" && currentSection && scrollContainerRef.current) {
       const currentIndex = virtualItems.items.findIndex(
@@ -122,7 +122,7 @@ export function VirtualizedToc({
     }
   }, [currentSection, virtualItems, itemHeight, variant]);
 
-  // 🎯 빈 상태 처리
+  // 빈 상태 처리
   if (!toc || toc.length === 0) {
     const EmptyIcon = variant === "simple" ? Book : BookOpen;
     const emptyMessage =
@@ -145,7 +145,6 @@ export function VirtualizedToc({
 
   return (
     <div className={className}>
-      {/* 제목 (showTitle이 true이고 propToc가 없을 때만) */}
       {showTitle && !propToc && (
         <h3 className="mb-4 text-lg font-medium">목차</h3>
       )}
@@ -190,7 +189,7 @@ export function VirtualizedToc({
                   }}
                 />
               ) : (
-                /* eslint-disable */
+                /*eslint-disable*/
                 <div
                   key={`${item.id || item.href}-${item.index}`}
                   className="py-1"
@@ -247,11 +246,4 @@ export function VirtualizedToc({
       )}
     </div>
   );
-}
-
-// 🎯 SimpleVirtualizedToc를 위한 편의 함수
-export function SimpleVirtualizedToc(
-  props: Omit<VirtualizedTocProps, "variant">,
-) {
-  return <VirtualizedToc {...props} variant="simple" showTitle={false} />;
 }

--- a/apps/web/src/routes/my-kiwis/-kiwis/kiwi-detail-modal/information-tab.tsx
+++ b/apps/web/src/routes/my-kiwis/-kiwis/kiwi-detail-modal/information-tab.tsx
@@ -1,5 +1,5 @@
 import { Book, Calendar, Clock, User, Users } from "lucide-react";
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, memo } from "react";
 
 import tempUser from "#/DB/users";
 import { SimpleVirtualizedToc } from "#/components/virtual-toc/simple-virtualized-toc";
@@ -11,7 +11,7 @@ interface InformationTabProps {
   kiwi: Kiwi;
 }
 
-function InformationTab({ kiwi }: InformationTabProps) {
+const InformationTab = memo(({ kiwi }: InformationTabProps) => {
   const {
     adminId,
     bookMetadata,
@@ -22,6 +22,7 @@ function InformationTab({ kiwi }: InformationTabProps) {
     participants,
   } = kiwi;
 
+  // 실제로 비용이 큰 계산만 메모이제이션
   const admin = useMemo(
     () => participants.find((participant) => participant.userId === adminId),
     [participants, adminId],
@@ -33,7 +34,6 @@ function InformationTab({ kiwi }: InformationTabProps) {
     [participants],
   );
 
-  // 🎯 자주 변경되지 않는 함수만 메모이제이션
   const handleTocNavigate = useCallback((href: string) => {
     console.log("목차 네비게이션:", href);
     // TODO: 실제 구현에서는 모달을 닫고 해당 위치로 이동하는 로직 추가
@@ -133,6 +133,6 @@ function InformationTab({ kiwi }: InformationTabProps) {
       )}
     </div>
   );
-}
+});
 
 export default InformationTab;

--- a/apps/web/src/routes/my-kiwis/-kiwis/kiwi-detail-modal/information-tab.tsx
+++ b/apps/web/src/routes/my-kiwis/-kiwis/kiwi-detail-modal/information-tab.tsx
@@ -1,8 +1,8 @@
 import { Book, Calendar, Clock, User, Users } from "lucide-react";
-
-import { NavItem } from "@bookiwi/epubjs/types/navigation";
+import { useMemo, useCallback } from "react";
 
 import tempUser from "#/DB/users";
+import { SimpleVirtualizedToc } from "#/components/virtual-toc/simple-virtualized-toc";
 import { FALLBACK_IMAGE_URL } from "#/constants/kiwi";
 import { Kiwi } from "#/types/kiwi";
 import { formatDate, formatDateOnly } from "#/utils/format-date";
@@ -22,13 +22,22 @@ function InformationTab({ kiwi }: InformationTabProps) {
     participants,
   } = kiwi;
 
-  const admin = participants.find(
-    (participant) => participant.userId === adminId,
+  const admin = useMemo(
+    () => participants.find((participant) => participant.userId === adminId),
+    [participants, adminId],
   );
 
-  const currentParticipant = participants.find(
-    (participant) => participant.userId === tempUser.id,
+  const currentParticipant = useMemo(
+    () =>
+      participants.find((participant) => participant.userId === tempUser.id),
+    [participants],
   );
+
+  // 🎯 자주 변경되지 않는 함수만 메모이제이션
+  const handleTocNavigate = useCallback((href: string) => {
+    console.log("목차 네비게이션:", href);
+    // TODO: 실제 구현에서는 모달을 닫고 해당 위치로 이동하는 로직 추가
+  }, []);
 
   return (
     <div className="mb-10 space-y-6">
@@ -100,13 +109,18 @@ function InformationTab({ kiwi }: InformationTabProps) {
           </div>
         </div>
       </div>
+
       <div className="space-y-3">
         <h3 className="font-medium">목차</h3>
-        <ul className="max-h-60 overflow-y-auto pr-1">
-          {bookMetadata.toc.map((item, index) => (
-            <TocItem key={item.id} tocItem={item} numbering={`${index + 1}`} />
-          ))}
-        </ul>
+
+        <div className="overflow-hidden rounded-lg border border-gray-200">
+          <SimpleVirtualizedToc
+            toc={bookMetadata.toc}
+            maxHeight={300}
+            itemHeight={36}
+            onNavigate={handleTocNavigate}
+          />
+        </div>
       </div>
 
       {detailDescription && (
@@ -118,36 +132,6 @@ function InformationTab({ kiwi }: InformationTabProps) {
         </div>
       )}
     </div>
-  );
-}
-
-interface TocItemProps {
-  tocItem: NavItem;
-  numbering: string;
-}
-function TocItem({ tocItem, numbering }: TocItemProps) {
-  return (
-    <li className="py-1">
-      <div className="group flex items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-muted">
-        <span className="flex size-5 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
-          {numbering}
-        </span>
-        <span className="text-sm group-hover:text-primary">
-          {tocItem.label}
-        </span>
-      </div>
-      {tocItem.subitems && tocItem.subitems.length > 0 && (
-        <ul className="ml-7 mt-1 space-y-0.5 border-l border-muted pl-2">
-          {tocItem.subitems.map((subitem, index) => (
-            <TocItem
-              key={subitem.id}
-              tocItem={subitem}
-              numbering={`${numbering}.${index + 1}`}
-            />
-          ))}
-        </ul>
-      )}
-    </li>
   );
 }
 


### PR DESCRIPTION
폴더구조를 어케해야할지 모르겠어서 일단 컴포넌트에 박악는데 index에 바로내보내기 있어서 구조 바꾸는건 쉽게 할수있으니 바꿔야되면 알려주세요!

## 변경전 성능 및 요소 구조
![변경전 성능](https://github.com/user-attachments/assets/01d023e3-b8c7-4221-bcc4-b59937b2ef6c)

![변경전 요소](https://github.com/user-attachments/assets/d94faf38-c8ba-4c54-aec7-3c2e8031a2ba)


## 변경후 성능 및 요소 구조

![변경후 성능](https://github.com/user-attachments/assets/2feb43f6-7ac0-410b-8a28-b56386654be1)

![변경후 요소](https://github.com/user-attachments/assets/efaebe5d-9a1d-45eb-81b6-b0e3ca293ad1)



----------
변경전엔 처음에 모든 목차를 다 받아오고나서 돔에 바로 모든 요소를 그려넣음

변경후에는 모든 목차를 받아오는건 동일 하지만 목차리스트 컴포넌트 크기만큼만 돔에 요소를 그려넣음 (약 12개씩)