### PR TITLE
fix: prevent toggling center touch state when highlight is clicked after resizing

### DIFF
--- a/apps/web/src/routes/kiwi/-reader/atoms/book.ts
+++ b/apps/web/src/routes/kiwi/-reader/atoms/book.ts
@@ -29,8 +29,11 @@ export const initialIsSinglePageAtom = atom<boolean>(false);
 
 export const toggleCenterTouchedAtom = atom(null, (get, set) => {
   const selection = get(selectionAtom);
+  const highlightClicked = get(highlightClickedAtom);
   if (!selection || selection.toString().trim() === "") {
-    set(isCenterTouchedAtom, !get(isCenterTouchedAtom));
+    if (!highlightClicked) {
+      set(isCenterTouchedAtom, !get(isCenterTouchedAtom));
+    }
   }
 });
 


### PR DESCRIPTION
화면 크기 조정 후 하이라이트 클릭 시 상태 바가 토글되는 문제 해결