### PR TITLE
refactor: page navigation buttons into a single reusable component 

### DIFF
--- a/apps/web/src/routes/kiwi/-reader/components/flip-page-button.tsx
+++ b/apps/web/src/routes/kiwi/-reader/components/flip-page-button.tsx
@@ -4,14 +4,25 @@ import { useAtomValue, useSetAtom } from "@bookiwi/jotai";
 
 import { bookAtom, isCenterTouchedAtom } from "../atoms";
 
-function ReaderPrevPageButton(props: ComponentProps<"button">) {
+type ReaderPageButtonProps = ComponentProps<"button"> & {
+  direction: "prev" | "next";
+};
+
+function ReaderPageButton({
+  direction,
+  children,
+  ...rest
+}: ReaderPageButtonProps) {
   const book = useAtomValue(bookAtom);
-  const { children, ...rest } = props;
   const setCenterTouched = useSetAtom(isCenterTouchedAtom);
 
-  const goToPrevPage = () => {
+  const goToPage = () => {
     if (book && book.rendition) {
-      book.rendition.prev();
+      if (direction === "prev") {
+        book.rendition.prev();
+      } else {
+        book.rendition.next();
+      }
       setCenterTouched(false);
     }
   };
@@ -20,7 +31,7 @@ function ReaderPrevPageButton(props: ComponentProps<"button">) {
     <button
       type="button"
       {...rest}
-      onClick={goToPrevPage}
+      onClick={goToPage}
       onMouseDown={(e) => e.preventDefault()}
       tabIndex={-1}
     >
@@ -29,29 +40,4 @@ function ReaderPrevPageButton(props: ComponentProps<"button">) {
   );
 }
 
-function ReaderNextPageButton(props: ComponentProps<"button">) {
-  const book = useAtomValue(bookAtom);
-  const { children, ...rest } = props;
-  const setCenterTouched = useSetAtom(isCenterTouchedAtom);
-
-  const goToNextPage = () => {
-    if (book && book.rendition) {
-      book.rendition.next();
-      setCenterTouched(false);
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      {...rest}
-      onClick={goToNextPage}
-      onMouseDown={(e) => e.preventDefault()}
-      tabIndex={-1}
-    >
-      {children}
-    </button>
-  );
-}
-
-export { ReaderPrevPageButton, ReaderNextPageButton };
+export default ReaderPageButton;

--- a/apps/web/src/routes/kiwi/-reader/components/index.ts
+++ b/apps/web/src/routes/kiwi/-reader/components/index.ts
@@ -1,5 +1,5 @@
 export { default as ReaderContents } from "./contents";
-export * from "./flip-page-button";
+export { default as ReaderPageButton } from "./flip-page-button";
 export { default as ReaderPageProgress } from "./page-progress";
 export { default as ReaderProvider } from "./provider";
 export { default as TextSelectionMenu } from "./text-selection-menu";

--- a/apps/web/src/routes/kiwi/-reader/components/page-progress.tsx
+++ b/apps/web/src/routes/kiwi/-reader/components/page-progress.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 
-import { useAtom, useAtomValue } from "@bookiwi/jotai";
+import { useAtomValue } from "@bookiwi/jotai";
 
 import { bookAtom, isCenterTouchedAtom, percentageAtom } from "../atoms";
 
@@ -8,18 +8,14 @@ import { Slider } from "#/components/ui/slider";
 import { throttle } from "#/utils/throttle";
 
 function ReaderPageProgress() {
-  const [isProgressBarOpen, setProgressBarOpen] = useAtom(isCenterTouchedAtom);
+  const isProgressBarOpen = useAtomValue(isCenterTouchedAtom);
 
   if (!isProgressBarOpen) return null;
 
-  return <ProgressBar setProgressBarOpen={setProgressBarOpen} />;
+  return <ProgressBar />;
 }
 
-function ProgressBar({
-  setProgressBarOpen,
-}: {
-  setProgressBarOpen: (value: boolean) => void;
-}) {
+function ProgressBar() {
   const book = useAtomValue(bookAtom);
   const storedPercentage = useAtomValue(percentageAtom);
   const [percentage, setPercentage] = useState(storedPercentage);
@@ -39,8 +35,7 @@ function ProgressBar({
   };
 
   return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-    <div className="size-full" onClick={() => setProgressBarOpen(true)}>
+    <div className="size-full">
       <div className="w-full space-y-2 bg-zinc-50 px-3 pt-2 transition-opacity duration-200">
         <div className="flex size-full justify-end text-sm text-black">
           <span>{`${percentage}%`}</span>

--- a/apps/web/src/routes/kiwi/-split-view/book/index.tsx
+++ b/apps/web/src/routes/kiwi/-split-view/book/index.tsx
@@ -3,21 +3,26 @@ import { memo } from "react";
 
 import {
   ReaderContents,
-  ReaderNextPageButton,
+  ReaderPageButton,
   ReaderPageProgress,
-  ReaderPrevPageButton,
 } from "../../-reader";
 
 function Book() {
   return (
     <section className="relative size-full px-20 pb-16">
-      <ReaderPrevPageButton className="group/button absolute left-0 top-0 flex h-full w-20 items-center justify-center">
+      <ReaderPageButton
+        direction="prev"
+        className="group/button absolute left-0 top-0 flex h-full w-20 items-center justify-center"
+      >
         <ChevronLeftIcon className="size-6 opacity-0 transition-opacity group-hover/button:opacity-100" />
-      </ReaderPrevPageButton>
+      </ReaderPageButton>
       <ReaderContents />
-      <ReaderNextPageButton className="group/button absolute right-0 top-0 flex h-full w-20 items-center justify-center">
+      <ReaderPageButton
+        direction="next"
+        className="group/button absolute right-0 top-0 flex h-full w-20 items-center justify-center"
+      >
         <ChevronRightIcon className="size-6 opacity-0 transition-opacity group-hover/button:opacity-100" />
-      </ReaderNextPageButton>
+      </ReaderPageButton>
       <div className="absolute inset-x-0 bottom-0 h-16">
         <ReaderPageProgress />
       </div>


### PR DESCRIPTION
페이지 넘기는 버튼 2개를 하나의 컴포넌트로 합치고 prop으로 분기 처리, 중복 코드 최소화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Unified previous/next navigation into a single ReaderPageButton used across the reader and split-view, simplifying controls without changing layout or styling.

- UI/UX
  - Progress bar visibility now follows the center-tap gesture only; clicking inside the progress bar no longer re-opens it.
  - Progress bar remains self-contained, showing current percentage and slider when available.
  - Navigation behavior is unchanged: left/right controls still move between pages as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->