### PR TITLE
fix: text selection overflowing beyond page bounds

### DIFF
--- a/apps/web/src/routes/kiwi/-header/bookmark-button.tsx
+++ b/apps/web/src/routes/kiwi/-header/bookmark-button.tsx
@@ -1,27 +1,15 @@
 import { Bookmark } from "lucide-react";
 
-import { EpubCFI } from "@bookiwi/epubjs";
 import { useAtomValue, useSetAtom } from "@bookiwi/jotai";
 
 import {
   bookmarksAtom,
-  Cfi,
   currentCfiAtom,
   currentLocationAtom,
   removeBookmarkAtom,
   addBookmarkAtom,
 } from "../-reader/atoms";
-
-const isCfiInRange = (cfi: Cfi, currentCfi: Cfi): boolean => {
-  const cfiInstance = new EpubCFI();
-  const isStartInRange =
-    cfiInstance.compare(cfi.start, currentCfi.start) >= 0 &&
-    cfiInstance.compare(cfi.start, currentCfi.end) <= 0;
-  const isEndInRange =
-    cfiInstance.compare(cfi.end, currentCfi.start) >= 0 &&
-    cfiInstance.compare(cfi.end, currentCfi.end) <= 0;
-  return isStartInRange || isEndInRange;
-};
+import { isCfiInRange } from "../-reader/utils";
 
 function BookmarkButton() {
   const currentCfi = useAtomValue(currentCfiAtom);

--- a/apps/web/src/routes/kiwi/-header/sidebar/panels/bookmarks.tsx
+++ b/apps/web/src/routes/kiwi/-header/sidebar/panels/bookmarks.tsx
@@ -6,9 +6,9 @@ import { Bookmark } from "@bookiwi/supabase/types";
 import {
   bookAtom,
   bookmarksAtom,
-  Cfi,
   removeBookmarkAtom,
 } from "#/routes/kiwi/-reader/atoms";
+import { Cfi } from "#/routes/kiwi/-reader/types";
 import { formatDate } from "#/utils/format-date";
 
 function EmptyBookmarksView() {

--- a/apps/web/src/routes/kiwi/-reader/atoms/participant.ts
+++ b/apps/web/src/routes/kiwi/-reader/atoms/participant.ts
@@ -9,6 +9,7 @@ import {
   updateLineHeight,
   updateSinglePage,
 } from "../apis";
+import { Cfi } from "../types";
 import { updateCustomStyle } from "../utils";
 
 import { bookAtom } from "./book";
@@ -164,11 +165,6 @@ export const participantSettingsAtom = atom<{
     fontWeight,
   };
 });
-
-export interface Cfi {
-  start: string;
-  end: string;
-}
 
 export const currentCfiAtom = atom<Cfi | null>((get) => {
   const cfiStart = get(participantCfiStartAtom);

--- a/apps/web/src/routes/kiwi/-reader/hooks/use-selection-menu.ts
+++ b/apps/web/src/routes/kiwi/-reader/hooks/use-selection-menu.ts
@@ -10,12 +10,16 @@ import {
   selectedHighlightAtom,
   selectionAtom,
   highlightsAtom,
+  currentCfiAtom,
 } from "../atoms";
 import {
   AnchorMode,
   AnchorPosition,
   calculateAnchorOffset,
+  hasCfiPassed,
   isForwardSelection,
+  createCfiFromSelectionToPageEnd,
+  createRangeFromCfi,
 } from "../utils";
 
 interface TextSelection {
@@ -48,17 +52,43 @@ export const useSelectedText = (): TextSelection | null => {
   const currentView = useAtomValue(currentViewAtom);
   const highlights = useAtomValue(highlightsAtom);
   const isAnnotationPinned = useAtomValue(isAnnotationPinnedAtom);
-  if (!currentSection || !currentView) {
+  const currentCfi = useAtomValue(currentCfiAtom);
+  if (!currentSection || !currentView || !currentCfi) {
     return null;
   }
 
   if (selection) {
-    const range = selection.getRangeAt(0);
-    const text = range.toString();
-    const cfi = currentSection.cfiFromRange(range);
+    const selectedRange = selection.getRangeAt(0);
+    const selectedText = selectedRange.toString();
+    const selectedCfi = currentSection.cfiFromRange(selectedRange);
     const isForward = isForwardSelection(selection);
-    const existingHighlight = highlights.find((a) => a.cfi === cfi);
+    const existingHighlight = highlights.find((a) => a.cfi === selectedCfi);
     const isMine = existingHighlight?.participantId === participantId;
+
+    let cfi: string;
+    let range: Range;
+    let text: string;
+
+    if (hasCfiPassed(selectedCfi, currentCfi.end)) {
+      // 선택 영역이 현재 페이지를 벗어난 경우
+      cfi = createCfiFromSelectionToPageEnd(selectedCfi, currentCfi.end);
+
+      // 새로운 CFI로부터 Range 생성
+      const newRange = createRangeFromCfi(cfi, currentView);
+      if (newRange) {
+        range = newRange;
+        text = newRange.toString();
+      } else {
+        // Range 생성에 실패한 경우 원본 사용
+        range = selectedRange;
+        text = selectedText;
+      }
+    } else {
+      // 선택 영역이 현재 페이지 내에 있는 경우
+      cfi = selectedCfi;
+      range = selectedRange;
+      text = selectedText;
+    }
 
     const remove = () => {
       selection.removeAllRanges();

--- a/apps/web/src/routes/kiwi/-reader/hooks/use-selection-menu.ts
+++ b/apps/web/src/routes/kiwi/-reader/hooks/use-selection-menu.ts
@@ -18,7 +18,8 @@ import {
   calculateAnchorOffset,
   hasCfiPassed,
   isForwardSelection,
-  createCfiFromSelectionToPageEnd,
+  extractStartCfiFromRange,
+  buildRangeCfi,
 } from "../utils";
 
 interface TextSelection {
@@ -69,7 +70,10 @@ export const useSelectedText = (): TextSelection | null => {
 
     if (hasCfiPassed(selectedCfi, currentCfi.end)) {
       // 선택 영역이 현재 페이지를 벗어난 경우
-      cfi = createCfiFromSelectionToPageEnd(selectedCfi, currentCfi.end);
+
+      // 선택 영역이 현재 페이지를 벗어난 경우, 선택 영역의 시작점부터 페이지 끝까지의 범위 CFI를 생성
+      const startCfi = extractStartCfiFromRange(selectedCfi);
+      cfi = buildRangeCfi(startCfi, currentCfi.end);
       range = currentView.contents.range(cfi);
       text = range.toString();
     } else {

--- a/apps/web/src/routes/kiwi/-reader/hooks/use-selection-menu.ts
+++ b/apps/web/src/routes/kiwi/-reader/hooks/use-selection-menu.ts
@@ -19,7 +19,6 @@ import {
   hasCfiPassed,
   isForwardSelection,
   createCfiFromSelectionToPageEnd,
-  createRangeFromCfi,
 } from "../utils";
 
 interface TextSelection {
@@ -59,7 +58,6 @@ export const useSelectedText = (): TextSelection | null => {
 
   if (selection) {
     const selectedRange = selection.getRangeAt(0);
-    const selectedText = selectedRange.toString();
     const selectedCfi = currentSection.cfiFromRange(selectedRange);
     const isForward = isForwardSelection(selection);
     const existingHighlight = highlights.find((a) => a.cfi === selectedCfi);
@@ -72,22 +70,13 @@ export const useSelectedText = (): TextSelection | null => {
     if (hasCfiPassed(selectedCfi, currentCfi.end)) {
       // 선택 영역이 현재 페이지를 벗어난 경우
       cfi = createCfiFromSelectionToPageEnd(selectedCfi, currentCfi.end);
-
-      // 새로운 CFI로부터 Range 생성
-      const newRange = createRangeFromCfi(cfi, currentView);
-      if (newRange) {
-        range = newRange;
-        text = newRange.toString();
-      } else {
-        // Range 생성에 실패한 경우 원본 사용
-        range = selectedRange;
-        text = selectedText;
-      }
+      range = currentView.contents.range(cfi);
+      text = range.toString();
     } else {
       // 선택 영역이 현재 페이지 내에 있는 경우
       cfi = selectedCfi;
       range = selectedRange;
-      text = selectedText;
+      text = selectedRange.toString();
     }
 
     const remove = () => {

--- a/apps/web/src/routes/kiwi/-reader/index.ts
+++ b/apps/web/src/routes/kiwi/-reader/index.ts
@@ -1,2 +1,1 @@
 export * from "./components";
-export * from "./utils";

--- a/apps/web/src/routes/kiwi/-reader/types/index.ts
+++ b/apps/web/src/routes/kiwi/-reader/types/index.ts
@@ -1,0 +1,4 @@
+export interface Cfi {
+  start: string;
+  end: string;
+}

--- a/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
+++ b/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
@@ -12,3 +12,95 @@ export const isCfiInRange = (cfi: Cfi, currentCfi: Cfi): boolean => {
     cfiInstance.compare(cfi.end, currentCfi.end) <= 0;
   return isStartInRange || isEndInRange;
 };
+
+/**
+ * 주어진 대상 CFI가 비교 CFI를 지났는지 확인합니다.
+ * 범위 CFI인 경우 끝점을 기준으로, 단일 CFI인 경우 해당 위치를 기준으로 비교합니다.
+ * @param {string} targetCfi 확인하려는 대상 CFI (단일 CFI 또는 범위 CFI).
+ * @param {string} comparisonCfi 비교 기준이 되는 CFI.
+ * @returns {boolean} 대상 CFI가 비교 CFI를 지났으면 true, 그렇지 않으면 false.
+ */
+export const hasCfiPassed = (
+  targetCfi: string,
+  comparisonCfi: string,
+): boolean => {
+  const cfiInstance = new EpubCFI();
+
+  let cfiToCompare = targetCfi;
+  if (targetCfi.includes(",")) {
+    const rangeParts = targetCfi.split(",");
+    if (rangeParts.length >= 3 && rangeParts[0] && rangeParts[2]) {
+      const basePath = rangeParts[0];
+      const endPath = rangeParts[2];
+      cfiToCompare = basePath + endPath;
+    }
+  }
+
+  return cfiInstance.compare(cfiToCompare, comparisonCfi) > 0;
+};
+
+/**
+ * 선택한 텍스트의 시작점부터 현재 페이지 끝까지의 CFI 범위를 생성합니다.
+ * @param {string} selectedCfi 선택된 텍스트의 CFI (단일 CFI 또는 범위 CFI)
+ * @param {string} pageEndCfi 현재 페이지 끝의 CFI
+ * @returns {string} 선택 시작점부터 페이지 끝까지의 CFI 범위
+ */
+export const createCfiFromSelectionToPageEnd = (
+  selectedCfi: string,
+  pageEndCfi: string,
+): string => {
+  // 선택된 CFI가 범위 CFI인지 확인 (쉼표로 구분되는지 체크)
+  const isRangeCfi = selectedCfi.includes(",");
+
+  let startCfi: string;
+
+  if (isRangeCfi) {
+    const rangeParts = selectedCfi.split(",");
+    if (rangeParts.length >= 2 && rangeParts[0] && rangeParts[1]) {
+      const basePath = rangeParts[0];
+      const startPath = rangeParts[1];
+      startCfi = basePath + startPath;
+    } else {
+      startCfi = selectedCfi;
+    }
+  } else {
+    startCfi = selectedCfi;
+  }
+
+  const basePart = startCfi.substring(8);
+  const baseIndex = basePart.indexOf("!");
+
+  if (baseIndex === -1) {
+    return `epubcfi(${basePart},${pageEndCfi.substring(8, pageEndCfi.length - 1)})`;
+  }
+
+  const base = basePart.substring(0, baseIndex + 1);
+  const startPath = basePart.substring(baseIndex + 1, basePart.length - 1);
+  const endPath = pageEndCfi.substring(
+    pageEndCfi.indexOf("!") + 1,
+    pageEndCfi.length - 1,
+  );
+
+  return `epubcfi(${base},${startPath},${endPath})`;
+};
+
+/**
+ * CFI로부터 Range 객체를 생성합니다.
+ * @param {string} cfi CFI 문자열
+ * @param {any} currentView 현재 뷰 객체 (contents 속성을 가진)
+ * @returns {Range | null} 생성된 Range 객체 또는 null
+ */
+export const createRangeFromCfi = (
+  cfi: string,
+  currentView: any,
+): Range | null => {
+  try {
+    if (!currentView?.contents) {
+      return null;
+    }
+    return currentView.contents.range(cfi);
+  } catch (error) {
+    console.error("Failed to create range from CFI:", error);
+    return null;
+  }
+};

--- a/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
+++ b/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
@@ -1,0 +1,14 @@
+import { EpubCFI } from "@bookiwi/epubjs";
+
+import { Cfi } from "../types";
+
+export const isCfiInRange = (cfi: Cfi, currentCfi: Cfi): boolean => {
+  const cfiInstance = new EpubCFI();
+  const isStartInRange =
+    cfiInstance.compare(cfi.start, currentCfi.start) >= 0 &&
+    cfiInstance.compare(cfi.start, currentCfi.end) <= 0;
+  const isEndInRange =
+    cfiInstance.compare(cfi.end, currentCfi.start) >= 0 &&
+    cfiInstance.compare(cfi.end, currentCfi.end) <= 0;
+  return isStartInRange || isEndInRange;
+};

--- a/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
+++ b/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
@@ -83,24 +83,3 @@ export const createCfiFromSelectionToPageEnd = (
 
   return `epubcfi(${base},${startPath},${endPath})`;
 };
-
-/**
- * CFI로부터 Range 객체를 생성합니다.
- * @param {string} cfi CFI 문자열
- * @param {any} currentView 현재 뷰 객체 (contents 속성을 가진)
- * @returns {Range | null} 생성된 Range 객체 또는 null
- */
-export const createRangeFromCfi = (
-  cfi: string,
-  currentView: any,
-): Range | null => {
-  try {
-    if (!currentView?.contents) {
-      return null;
-    }
-    return currentView.contents.range(cfi);
-  } catch (error) {
-    console.error("Failed to create range from CFI:", error);
-    return null;
-  }
-};

--- a/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
+++ b/apps/web/src/routes/kiwi/-reader/utils/cfi.ts
@@ -40,46 +40,70 @@ export const hasCfiPassed = (
 };
 
 /**
- * 선택한 텍스트의 시작점부터 현재 페이지 끝까지의 CFI 범위를 생성합니다.
- * @param {string} selectedCfi 선택된 텍스트의 CFI (단일 CFI 또는 범위 CFI)
- * @param {string} pageEndCfi 현재 페이지 끝의 CFI
- * @returns {string} 선택 시작점부터 페이지 끝까지의 CFI 범위
+ * 범위 CFI에서 시작점 CFI를 추출합니다.
+ * @param {string} cfi 범위 CFI 또는 단일 CFI
+ * @returns {string} 시작점 CFI
  */
-export const createCfiFromSelectionToPageEnd = (
-  selectedCfi: string,
-  pageEndCfi: string,
-): string => {
-  // 선택된 CFI가 범위 CFI인지 확인 (쉼표로 구분되는지 체크)
-  const isRangeCfi = selectedCfi.includes(",");
+export const extractStartCfiFromRange = (cfi: string): string => {
+  const isRangeCfi = cfi.includes(",");
 
-  let startCfi: string;
-
-  if (isRangeCfi) {
-    const rangeParts = selectedCfi.split(",");
-    if (rangeParts.length >= 2 && rangeParts[0] && rangeParts[1]) {
-      const basePath = rangeParts[0];
-      const startPath = rangeParts[1];
-      startCfi = basePath + startPath;
-    } else {
-      startCfi = selectedCfi;
-    }
-  } else {
-    startCfi = selectedCfi;
+  if (!isRangeCfi) {
+    return cfi;
   }
 
-  const basePart = startCfi.substring(8);
+  const rangeParts = cfi.split(",");
+  if (rangeParts.length >= 2 && rangeParts[0] && rangeParts[1]) {
+    const basePath = rangeParts[0];
+    const startPath = rangeParts[1];
+    return basePath + startPath;
+  }
+
+  return cfi;
+};
+
+/**
+ * CFI 문자열에서 경로 구성 요소들을 파싱합니다.
+ * @param {string} cfi CFI 문자열
+ * @returns {object} 파싱된 CFI 구성 요소들
+ */
+export const parseCfiComponents = (cfi: string) => {
+  const basePart = cfi.substring(8); // "epubcfi(" 제거
   const baseIndex = basePart.indexOf("!");
 
   if (baseIndex === -1) {
-    return `epubcfi(${basePart},${pageEndCfi.substring(8, pageEndCfi.length - 1)})`;
+    return {
+      hasBase: false,
+      basePart,
+      base: "",
+      path: "",
+    };
   }
 
   const base = basePart.substring(0, baseIndex + 1);
-  const startPath = basePart.substring(baseIndex + 1, basePart.length - 1);
-  const endPath = pageEndCfi.substring(
-    pageEndCfi.indexOf("!") + 1,
-    pageEndCfi.length - 1,
-  );
+  const path = basePart.substring(baseIndex + 1, basePart.length - 1);
 
-  return `epubcfi(${base},${startPath},${endPath})`;
+  return {
+    hasBase: true,
+    basePart,
+    base,
+    path,
+  };
+};
+
+/**
+ * 두 CFI를 사용해서 범위 CFI를 구성합니다.
+ * @param {string} startCfi 시작점 CFI
+ * @param {string} endCfi 끝점 CFI
+ * @returns {string} 구성된 범위 CFI
+ */
+export const buildRangeCfi = (startCfi: string, endCfi: string): string => {
+  const startComponents = parseCfiComponents(startCfi);
+
+  if (!startComponents.hasBase) {
+    return `epubcfi(${startComponents.basePart},${endCfi.substring(8, endCfi.length - 1)})`;
+  }
+
+  const endPath = endCfi.substring(endCfi.indexOf("!") + 1, endCfi.length - 1);
+
+  return `epubcfi(${startComponents.base},${startComponents.path},${endPath})`;
 };

--- a/apps/web/src/routes/kiwi/-reader/utils/index.ts
+++ b/apps/web/src/routes/kiwi/-reader/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./nav";
 export * from "./styles";
 export * from "./selection";
 export * from "./anchor";
+export * from "./cfi";


### PR DESCRIPTION
드래그를 길게 했을 때 다음 페이지까지 문장이 선택되어 메뉴 렌더링 위치가 망가지고, 뒷 페이지까지 하이라이트가 되는 버그를 고침.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support selecting text across page boundaries; actions like highlight/copy now work for multi-page selections.

- Bug Fixes
  - Improved accuracy of the bookmark indicator when your current position overlaps a bookmarked range.
  - More reliable selection menu behavior at page edges and during long selections.

- Refactor
  - Centralized navigation/position handling into shared utilities and standardized types.
  - Streamlined internal exports to reduce surface area without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->